### PR TITLE
debian: remove network-manager-gnome dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -88,8 +88,7 @@ Recommends: cups-pk-helper,
             mousetweaks,
             ntp,
             rygel | rygel-tracker,
-            system-config-printer (>= 1.4),
-            network-manager-gnome (>= 0.9.8)
+            system-config-printer (>= 1.4)
 Breaks: gnome-power-manager (<< 3.0),
         gnome-session (<< 3.0),
         libglib2.0-0 (<< 2.28.6-2),


### PR DESCRIPTION
[endlessm/eos-shell#2535]
