### PR TITLE
Allow Gnome control center to enable/disable metrics

### DIFF
--- a/panels/common/gnome-control-center.rules
+++ b/panels/common/gnome-control-center.rules
@@ -1,5 +1,6 @@
 polkit.addRule(function(action, subject) {
-	if ((action.id == "org.freedesktop.locale1.set-locale" ||
+	if ((action.id == "com.endlessm.Metrics.SetEnabled" ||
+	     action.id == "org.freedesktop.locale1.set-locale" ||
 	     action.id == "org.freedesktop.locale1.set-keyboard" ||
 	     action.id == "org.freedesktop.hostname1.set-static-hostname" ||
 	     action.id == "org.freedesktop.hostname1.set-hostname" ||


### PR DESCRIPTION
Added Polkit rules, don't require an unlock for the control center.
[endlessm/eos-sdk#1327]
