### PR TITLE
info: don't change state before asserting

### DIFF
--- a/panels/info/cc-info-panel.c
+++ b/panels/info/cc-info-panel.c
@@ -1567,9 +1567,9 @@ updates_link_activated (GtkLabel *label,
 {
   OTDState state;
 
-  self->priv->ostree_activated = TRUE;
   state = otd__get_state (self->priv->ostree_proxy);
   g_assert (is_otd_state_interactive (self, state));
+  self->priv->ostree_activated = TRUE;
 
   switch (state)
     {


### PR DESCRIPTION
Setting priv->ostree_activated to TRUE will change the interactive-ness
of the state; don't do that before asserting that the state we got here
with was interactive.

[endlessm/eos-shell#3678]
