### PR TITLE
region: don't crash for locales with no country_code

### DIFF
--- a/panels/region/cc-input-chooser.c
+++ b/panels/region/cc-input-chooser.c
@@ -1017,9 +1017,9 @@ get_locale_infos (GtkWidget *chooser)
         continue;
 
       if (country_code != NULL)
-	simple_locale = g_strdup_printf ("%s_%s.utf8", lang_code, country_code);
+        simple_locale = g_strdup_printf ("%s_%s.utf8", lang_code, country_code);
       else
-	simple_locale = g_strdup_printf ("%s.utf8", lang_code);
+        simple_locale = g_strdup_printf ("%s.utf8", lang_code);
 
       if (g_hash_table_contains (priv->locales, simple_locale))
         {


### PR DESCRIPTION
gnome_parse_locale() can return an empty country_code for some locales,
which we are not taking into account when building the simple_locale
string.

[endlessm/eos-shell#4017]
