### PR TITLE
Add NoDisplay to all gnome-control-center panel .desktop files

### DIFF
--- a/panels/background/gnome-background-panel.desktop.in.in
+++ b/panels/background/gnome-background-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center background
 Icon=preferences-desktop-wallpaper
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;
 OnlyShowIn=GNOME;

--- a/panels/bluetooth/gnome-bluetooth-panel.desktop.in.in
+++ b/panels/bluetooth/gnome-bluetooth-panel.desktop.in.in
@@ -5,6 +5,7 @@ Icon=bluetooth
 Exec=gnome-control-center bluetooth
 Terminal=false
 Type=Application
+NoDisplay=true
 Categories=GTK;GNOME;Settings;X-GNOME-NetworkSettings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;
 StartupNotify=true

--- a/panels/color/gnome-color-panel.desktop.in.in
+++ b/panels/color/gnome-color-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center color
 Icon=preferences-color
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-Settings-Panel;HardwareSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/datetime/gnome-datetime-panel.desktop.in.in
+++ b/panels/datetime/gnome-datetime-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center datetime
 Icon=preferences-system-time
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;

--- a/panels/display/gnome-display-panel.desktop.in.in
+++ b/panels/display/gnome-display-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center display
 Icon=preferences-desktop-display
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;

--- a/panels/info/gnome-info-panel.desktop.in.in
+++ b/panels/info/gnome-info-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center info
 Icon=applications-system
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;

--- a/panels/keyboard/gnome-keyboard-panel.desktop.in.in
+++ b/panels/keyboard/gnome-keyboard-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center keyboard
 Icon=input-keyboard
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;

--- a/panels/mouse/gnome-mouse-panel.desktop.in.in
+++ b/panels/mouse/gnome-mouse-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center mouse
 Icon=input-mouse
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;

--- a/panels/network/gnome-network-panel.desktop.in.in
+++ b/panels/network/gnome-network-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center network
 Icon=network-workgroup
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;

--- a/panels/notifications/gnome-notifications-panel.desktop.in.in
+++ b/panels/notifications/gnome-notifications-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center notifications
 Icon=preferences-system-notifications
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/online-accounts/gnome-online-accounts-panel.desktop.in.in
+++ b/panels/online-accounts/gnome-online-accounts-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center online-accounts
 Icon=goa-panel
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/power/gnome-power-panel.desktop.in.in
+++ b/panels/power/gnome-power-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center power
 Icon=gnome-power-manager
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;HardwareSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/printers/gnome-printers-panel.desktop.in.in
+++ b/panels/printers/gnome-printers-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center printers
 Icon=printer
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 # The X-GNOME-Settings-Panel is necessary to show in the main shell UI
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;

--- a/panels/privacy/gnome-privacy-panel.desktop.in.in
+++ b/panels/privacy/gnome-privacy-panel.desktop.in.in
@@ -6,6 +6,7 @@ Exec=gnome-control-center privacy
 Icon=preferences-system-privacy
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/region/gnome-region-panel.desktop.in.in
+++ b/panels/region/gnome-region-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center region
 Icon=preferences-desktop-locale
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/search/gnome-search-panel.desktop.in.in
+++ b/panels/search/gnome-search-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center search
 Icon=preferences-system-search
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/sharing/gnome-sharing-panel.desktop.in.in
+++ b/panels/sharing/gnome-sharing-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center sharing
 Icon=preferences-system-sharing
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-SystemSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/sound/data/gnome-sound-panel.desktop.in.in
+++ b/panels/sound/data/gnome-sound-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center sound
 Icon=multimedia-volume-control
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;

--- a/panels/universal-access/gnome-universal-access-panel.desktop.in.in
+++ b/panels/universal-access/gnome-universal-access-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center universal-access
 Icon=preferences-desktop-accessibility
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;

--- a/panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in
+++ b/panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center user-accounts
 Icon=system-users
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=System;Settings;X-GNOME-Settings-Panel;X-GNOME-SystemSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/wacom/gnome-wacom-panel.desktop.in.in
+++ b/panels/wacom/gnome-wacom-panel.desktop.in.in
@@ -5,6 +5,7 @@ Exec=gnome-control-center wacom
 Icon=input-tablet
 Terminal=false
 Type=Application
+NoDisplay=true
 StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;


### PR DESCRIPTION
These aren't apps -- they're simply launchers for gnome-control-center.
They should not be shown as apps in the UI at all.

https://bugzilla.gnome.org/show_bug.cgi?id=712246

endlessm/eos-shell#4371