### PR TITLE
Recommend system-config-printer-gnome

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -85,7 +85,7 @@ Recommends: cups-pk-helper,
             mousetweaks,
             ntp,
             rygel | rygel-tracker,
-            system-config-printer (>= 1.4)
+            system-config-printer-gnome | system-config-printer (>= 1.4)
 Breaks: gnome-power-manager (<< 3.0),
         gnome-session (<< 3.0),
         libglib2.0-0 (<< 2.28.6-2),


### PR DESCRIPTION
Our new system-config-printer replaces the system-config-printer package
with a virtual provides from system-config-printer-gnome. Apt seems to
get confused about the existence of a real system-config-printer in our
repo from extra, which pulls in unwanted dependencies. Prefer
system-config-printer-gnome here to avoid that situation.

[endlessm/eos-shell#4481]