### PR TITLE
Update the locale format along with the language when it changes

### DIFF
--- a/panels/region/cc-region-panel.c
+++ b/panels/region/cc-region-panel.c
@@ -381,6 +381,8 @@ update_language (CcRegionPanel *self,
         }
 }
 
+static void update_region (CcRegionPanel *self, const gchar *region);
+
 static void
 language_response (GtkDialog     *chooser,
                    gint           response_id,
@@ -391,6 +393,10 @@ language_response (GtkDialog     *chooser,
         if (response_id == GTK_RESPONSE_OK) {
                 language = cc_language_chooser_get_language (GTK_WIDGET (chooser));
                 update_language (self, language);
+
+                /* Update the format too to keep it consistent with the language
+                   when it changes, as it's probably the right thing to do. */
+                update_region (self, language);
         }
 
         gtk_widget_destroy (GTK_WIDGET (chooser));


### PR DESCRIPTION
Not doing this will lead to (probably undesired) inconsistencies when
changing the language, since many locale-dependant strings will still be
rendered considering the previous language format (e.g. days of the week).

[endlessm/eos-shell#3586]