### PR TITLE
sharing: use correct name for SSH service

### DIFF
--- a/panels/sharing/cc-remote-login-helper.c
+++ b/panels/sharing/cc-remote-login-helper.c
@@ -20,7 +20,7 @@
  */
 
 #include <gio/gio.h>
-#define SSHD_SERVICE "sshd.service"
+#define SSHD_SERVICE "ssh.service"
 
 static const gchar *service_list[] = { SSHD_SERVICE, NULL };
 

--- a/panels/sharing/cc-remote-login.c
+++ b/panels/sharing/cc-remote-login.c
@@ -21,7 +21,7 @@
 #include "cc-remote-login.h"
 #include <gio/gio.h>
 
-#define SSHD_SERVICE "sshd.service"
+#define SSHD_SERVICE "ssh.service"
 
 typedef struct
 {


### PR DESCRIPTION
Debian calls it "ssh.service".

[endlessm/eos-shell#4824]