### PR TITLE
Use org.freedesktop.login1.Manager.CanSuspend from the power panel

### DIFF
--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -2143,6 +2143,40 @@ add_device_section (CcPowerPanel *self)
   gtk_widget_show_all (box);
 }
 
+static gboolean
+can_suspend ()
+{
+  GDBusConnection *connection;
+  GVariant *reply;
+  gboolean result;
+
+  connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);
+  reply = g_dbus_connection_call_sync (connection,
+                                       "org.freedesktop.login1",
+                                       "/org/freedesktop/login1",
+                                       "org.freedesktop.login1.Manager",
+                                       "CanSuspend",
+                                       NULL,
+                                       NULL,
+                                       G_DBUS_CALL_FLAGS_NONE,
+                                       -1,
+                                       NULL,
+                                       NULL);
+  g_object_unref (connection);
+
+  result = FALSE;
+  if (reply)
+    {
+      gchar *s;
+      g_variant_get (reply, "(&s)", &s);
+      if (g_strcmp0 (s, "yes") == 0)
+        result = TRUE;
+      g_variant_unref(reply);
+    }
+
+  return result;
+}
+
 static void
 on_content_size_changed (GtkWidget *widget, GtkAllocation *allocation, gpointer data)
 {
@@ -2223,7 +2257,9 @@ cc_power_panel_init (CcPowerPanel *self)
   add_battery_section (self);
   add_device_section (self);
   add_power_saving_section (self);
-  add_automatic_suspend_section (self);
+
+  if (can_suspend ())
+    add_automatic_suspend_section (self);
 
   priv->boxes = g_list_copy (priv->boxes_reverse);
   priv->boxes = g_list_reverse (priv->boxes);

--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -2223,9 +2223,7 @@ cc_power_panel_init (CcPowerPanel *self)
   add_battery_section (self);
   add_device_section (self);
   add_power_saving_section (self);
-
-  // XXX: Removed from UI until product design dictates otherwise
-  // add_automatic_suspend_section (self);
+  add_automatic_suspend_section (self);
 
   priv->boxes = g_list_copy (priv->boxes_reverse);
   priv->boxes = g_list_reverse (priv->boxes);

--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -1128,7 +1128,8 @@ set_ac_battery_ui_mode (CcPowerPanel *self)
 out:
   self->priv->has_batteries = has_batteries;
 
-  gtk_widget_set_visible (self->priv->critical_battery_row, has_batteries);
+  if (self->priv->critical_battery_row)
+    gtk_widget_set_visible (self->priv->critical_battery_row, has_batteries);
 
   if (!has_batteries)
     {
@@ -1747,7 +1748,8 @@ update_automatic_suspend_label (CcPowerPanel *self)
         s = _("On");
     }
 
-  gtk_label_set_label (GTK_LABEL (priv->automatic_suspend_label), s);
+  if (priv->automatic_suspend_label)
+    gtk_label_set_label (GTK_LABEL (priv->automatic_suspend_label), s);
 }
 
 static void


### PR DESCRIPTION
Show "Suspend & Power Off" section only when system can suspend
Instead of disabling this section entirely, ask logind's D-Bus service
'org.freedesktop.login1.Manager.CanSuspend' to determine whether it
should be visible or not, similar to what GDM and the Shell already do.

Also, fix two critical messages while at it.

[endlessm/eos-shell#4655]