### PR TITLE
info: Adjust to new dbus interface

### DIFF
--- a/panels/info/Makefile.am
+++ b/panels/info/Makefile.am
@@ -13,8 +13,8 @@ noinst_LTLIBRARIES = libinfo.la
 BUILT_SOURCES =			\
 	cc-info-resources.c	\
 	cc-info-resources.h	\
-	ostree-daemon-generated.c \
-	ostree-daemon-generated.h
+	eos-updater-generated.c \
+	eos-updater-generated.h
 
 libinfo_la_SOURCES =		\
 	$(BUILT_SOURCES)	\
@@ -31,12 +31,12 @@ cc-info-resources.c: info.gresource.xml $(resource_files)
 cc-info-resources.h: info.gresource.xml $(resource_files)
 	$(AM_V_GEN) glib-compile-resources --target=$@ --sourcedir=$(srcdir) --generate-header --c-name cc_info $<
 
-ostree-daemon-generated.c: ostree-daemon-generated.h
-ostree-daemon-generated.h: $(srcdir)/ostree-daemon.xml
+eos-updater-generated.c: eos-updater-generated.h
+eos-updater-generated.h: $(srcdir)/eos-updater.xml
 	gdbus-codegen $<				\
-	--interface-prefix org.gnome.OSTree		\
-	--generate-c-code ostree-daemon-generated	\
-	--c-namespace OTD
+	--interface-prefix com.endlessm.		\
+	--generate-c-code eos-updater-generated		\
+	--c-namespace Eos
 
 @INTLTOOL_DESKTOP_RULE@
 
@@ -51,6 +51,6 @@ update-from-gsd:
 	git commit -m "info: Update from gnome-settings-daemon" $(SPACEFILES)
 
 CLEANFILES = $(desktop_in_files) $(desktop_DATA) $(BUILT_SOURCES)
-EXTRA_DIST = $(resource_files) info.gresource.xml $(srcdir)/ostree-daemon.xml
+EXTRA_DIST = $(resource_files) info.gresource.xml $(srcdir)/eos-updater.xml
 
 -include $(top_srcdir)/git.mk

--- a/panels/info/eos-updater.xml
+++ b/panels/info/eos-updater.xml
@@ -1,9 +1,9 @@
 <node>
-  <interface name="org.gnome.OSTree">
+  <interface name="com.endlessm.Updater">
     <method name="Poll" ></method>
     <method name="Fetch"></method>
     <method name="Apply"></method>
-
+    
     <property name="State"            type="u" access="read"/>
     <property name="UpdateID"         type="s" access="read"/>
     <property name="CurrentID"        type="s" access="read"/>
@@ -16,7 +16,7 @@
     <property name="FullUnpackedSize" type="x" access="read"/>
     <property name="ErrorCode"        type="u" access="read"/>
     <property name="ErrorMessage"     type="s" access="read"/>
-
+    
     <signal name="StateChanged">
       <arg type="u" name="state"/>
     </signal>


### PR DESCRIPTION
It was determined that the ostree daemon was not upstreamable, so the
interface has moved over to an Endless specific com.endlessm.Updater.

Copy in eos-updater.xml and adjust accordingly. The interface usage was
changed slightly so that the object is EosUpdater.

[endlessm/eos-shell#5087]