### PR TITLE
background: Set background items as pixbufs, not GIcons

### DIFF
--- a/panels/background/bg-colors-source.c
+++ b/panels/background/bg-colors-source.c
@@ -75,7 +75,7 @@ bg_colors_source_init (BgColorsSource *self)
     {
       CcBackgroundItemFlags flags;
       CcBackgroundItem *item;
-      GIcon *pixbuf;
+      GdkPixbuf *pixbuf;
 
       item = cc_background_item_new (NULL);
       flags = CC_BACKGROUND_ITEM_HAS_PCOLOR |

--- a/panels/background/bg-source.c
+++ b/panels/background/bg-source.c
@@ -107,7 +107,7 @@ bg_source_init (BgSource *self)
 
   priv = self->priv = SOURCE_PRIVATE (self);
 
-  priv->store = gtk_list_store_new (3, G_TYPE_ICON, G_TYPE_OBJECT, G_TYPE_STRING);
+  priv->store = gtk_list_store_new (3, GDK_TYPE_PIXBUF, G_TYPE_OBJECT, G_TYPE_STRING);
 }
 
 GtkListStore*

--- a/panels/background/bg-wallpapers-source.c
+++ b/panels/background/bg-wallpapers-source.c
@@ -97,7 +97,7 @@ load_wallpapers (gchar              *key,
 {
   BgWallpapersSourcePrivate *priv = source->priv;
   GtkTreeIter iter;
-  GIcon *pixbuf;
+  GdkPixbuf *pixbuf;
   GtkListStore *store = bg_source_get_liststore (BG_SOURCE (source));
   gboolean deleted;
 

--- a/panels/background/cc-background-chooser-dialog.c
+++ b/panels/background/cc-background-chooser-dialog.c
@@ -412,18 +412,12 @@ cc_background_chooser_dialog_init (CcBackgroundChooserDialog *chooser)
   g_signal_connect (priv->icon_view, "item-activated", G_CALLBACK (on_item_activated), chooser);
 
   renderer = gtk_cell_renderer_pixbuf_new ();
-  /* set stock size to 32px so that emblems render at 16px. see:
-   * https://bugzilla.gnome.org/show_bug.cgi?id=682123#c4
-   */
-  g_object_set (renderer,
-                "stock-size", GTK_ICON_SIZE_DND,
-                NULL);
   gtk_cell_layout_pack_start (GTK_CELL_LAYOUT (priv->icon_view),
                               renderer,
                               FALSE);
   gtk_cell_layout_set_attributes (GTK_CELL_LAYOUT (priv->icon_view),
                                   renderer,
-                                  "gicon", 0,
+                                  "pixbuf", 0,
                                   NULL);
 
   gtk_dialog_add_button (GTK_DIALOG (chooser), _("_Cancel"), GTK_RESPONSE_CANCEL);

--- a/panels/background/cc-background-item.c
+++ b/panels/background/cc-background-item.c
@@ -82,17 +82,6 @@ static void     cc_background_item_finalize       (GObject               *object
 
 G_DEFINE_TYPE (CcBackgroundItem, cc_background_item, G_TYPE_OBJECT)
 
-static GEmblem *
-get_slideshow_icon (void)
-{
-	GIcon *themed;
-	GEmblem *emblem;
-	themed = g_themed_icon_new ("slideshow-emblem");
-	emblem = g_emblem_new_with_origin (themed, G_EMBLEM_ORIGIN_DEVICE);
-	g_object_unref (themed);
-	return emblem;
-}
-
 static void
 set_bg_properties (CcBackgroundItem *item)
 {
@@ -170,7 +159,7 @@ render_at_size (GnomeBG *bg,
         return pixbuf;
 }
 
-GIcon *
+GdkPixbuf *
 cc_background_item_get_frame_thumbnail (CcBackgroundItem             *item,
                                         GnomeDesktopThumbnailFactory *thumbs,
                                         int                           width,
@@ -179,7 +168,6 @@ cc_background_item_get_frame_thumbnail (CcBackgroundItem             *item,
                                         gboolean                      force_size)
 {
         GdkPixbuf *pixbuf = NULL;
-        GIcon *icon = NULL;
 
 	g_return_val_if_fail (CC_IS_BACKGROUND_ITEM (item), NULL);
 	g_return_val_if_fail (width > 0 && height > 0, NULL);
@@ -212,19 +200,6 @@ cc_background_item_get_frame_thumbnail (CcBackgroundItem             *item,
                 }
         }
 
-        if (pixbuf != NULL
-            && frame != -2
-            && gnome_bg_changes_with_time (item->priv->bg)) {
-                GEmblem *emblem;
-
-                emblem = get_slideshow_icon ();
-                icon = g_emblemed_icon_new (G_ICON (pixbuf), emblem);
-                g_object_unref (emblem);
-                g_object_unref (pixbuf);
-        } else {
-                icon = G_ICON (pixbuf);
-	}
-
         gnome_bg_get_image_size (item->priv->bg,
                                  thumbs,
                                  width,
@@ -234,11 +209,11 @@ cc_background_item_get_frame_thumbnail (CcBackgroundItem             *item,
 
         update_size (item);
 
-        return icon;
+        return pixbuf;
 }
 
 
-GIcon *
+GdkPixbuf *
 cc_background_item_get_thumbnail (CcBackgroundItem             *item,
                                   GnomeDesktopThumbnailFactory *thumbs,
                                   int                           width,

--- a/panels/background/cc-background-item.h
+++ b/panels/background/cc-background-item.h
@@ -71,11 +71,11 @@ gboolean           cc_background_item_load                (CcBackgroundItem     
 							   GFileInfo                    *info);
 gboolean           cc_background_item_changes_with_time   (CcBackgroundItem             *item);
 
-GIcon     *        cc_background_item_get_thumbnail       (CcBackgroundItem             *item,
+GdkPixbuf *        cc_background_item_get_thumbnail       (CcBackgroundItem             *item,
                                                            GnomeDesktopThumbnailFactory *thumbs,
                                                            int                           width,
                                                            int                           height);
-GIcon     *        cc_background_item_get_frame_thumbnail (CcBackgroundItem             *item,
+GdkPixbuf *        cc_background_item_get_frame_thumbnail (CcBackgroundItem             *item,
                                                            GnomeDesktopThumbnailFactory *thumbs,
                                                            int                           width,
                                                            int                           height,

--- a/panels/background/cc-background-panel.c
+++ b/panels/background/cc-background-panel.c
@@ -191,7 +191,6 @@ update_display_preview (CcBackgroundPanel *panel)
   const gint preview_width = 416;
   const gint preview_height = 248;
   GdkPixbuf *pixbuf;
-  GIcon *icon;
   cairo_t *cr;
 
   widget = WID ("background-desktop-drawingarea");
@@ -200,12 +199,11 @@ update_display_preview (CcBackgroundPanel *panel)
   if (!priv->current_background)
     return;
 
-  icon = cc_background_item_get_frame_thumbnail (priv->current_background,
-                                                 priv->thumb_factory,
-                                                 preview_width,
-                                                 preview_height,
-                                                 -2, TRUE);
-  pixbuf = GDK_PIXBUF (icon);
+  pixbuf = cc_background_item_get_frame_thumbnail (priv->current_background,
+                                                   priv->thumb_factory,
+                                                   preview_width,
+                                                   preview_height,
+                                                   -2, TRUE);
 
   cr = gdk_cairo_create (gtk_widget_get_window (widget));
   gdk_cairo_set_source_pixbuf (cr,


### PR DESCRIPTION
Setting pixbufs as GIcons causes the CellRendererPixbuf to try to load
it at 32px ever since a GTK+ upgrade, so we can't do this anymore.

Upstream fixed this by porting away from GtkCellRenderer and instead to
GtkFlowBox, so that's why this hasn't been fixed there.

Setting the backgrounds as pixbufs means we can't have the GtkIconTheme
code apply emblems for time-changing backgrounds, but we don't ship any
time-changing backgrounds, so it shouldn't cause any major difference.

[endlessm/eos-shell#5356]