### PR TITLE
Issue/6133

### DIFF
--- a/panels/background/background.ui
+++ b/panels/background/background.ui
@@ -8,14 +8,13 @@
     <property name="margin_right">6</property>
     <property name="margin_top">6</property>
     <property name="margin_bottom">6</property>
-    <property name="border_width">10</property>
     <property name="spacing">12</property>
     <child>
       <object class="GtkBox" id="box1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_top">100</property>
-        <property name="margin_bottom">100</property>
+        <property name="margin_top">60</property>
+        <property name="margin_bottom">60</property>
         <child>
           <object class="GtkVBox" id="vbox3">
             <property name="visible">True</property>

--- a/panels/color/cc-color-panel.c
+++ b/panels/color/cc-color-panel.c
@@ -2285,7 +2285,7 @@ cc_color_panel_init (CcColorPanel *prefs)
   widget = GTK_WIDGET (gtk_builder_get_object (priv->builder,
                                                "scrolledwindow_devices"));
   gtk_scrolled_window_set_min_content_height (GTK_SCROLLED_WINDOW (widget),
-                                              300);
+                                              250);
 
   widget = GTK_WIDGET (gtk_builder_get_object (priv->builder,
                                                "toolbutton_device_default"));

--- a/panels/datetime/datetime.ui
+++ b/panels/datetime/datetime.ui
@@ -451,8 +451,8 @@
       <object class="GtkBox" id="vbox_datetime">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">134</property>
-        <property name="margin_right">134</property>
+        <property name="margin_left">80</property>
+        <property name="margin_right">80</property>
         <property name="margin_top">24</property>
         <property name="margin_bottom">24</property>
         <property name="orientation">vertical</property>

--- a/panels/info/cc-info-panel.c
+++ b/panels/info/cc-info-panel.c
@@ -100,6 +100,9 @@ struct _CcInfoPanelPrivate
 {
   GtkBuilder    *builder;
   GtkWidget     *extra_options_dialog;
+  GtkWidget     *scrolled_window;
+  GtkWidget     *detail_vbox;
+  GtkWidget     *hbox1;
 
   GCancellable  *cancellable;
 
@@ -375,6 +378,31 @@ cc_info_panel_finalize (GObject *object)
 }
 
 static void
+cc_info_panel_constructed (GObject *object)
+{
+  CcInfoPanel *self = CC_INFO_PANEL (object);
+  CcShell *shell;
+
+  G_OBJECT_CLASS (cc_info_panel_parent_class)->constructed (object);
+
+  shell = cc_panel_get_shell (CC_PANEL (object));
+
+  if (cc_shell_is_small_screen (shell))
+    {
+      GtkWidget *sw;
+
+      sw = gtk_scrolled_window_new (NULL, NULL);
+      gtk_scrolled_window_set_min_content_height (GTK_SCROLLED_WINDOW (sw), 380);
+
+      gtk_container_remove (GTK_CONTAINER (self->priv->hbox1), self->priv->detail_vbox);
+      gtk_container_add (GTK_CONTAINER (sw), self->priv->detail_vbox);
+      gtk_container_add (GTK_CONTAINER (self->priv->hbox1), sw);
+
+      gtk_widget_show (sw);
+    }
+}
+
+static void
 cc_info_panel_class_init (CcInfoPanelClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -383,6 +411,7 @@ cc_info_panel_class_init (CcInfoPanelClass *klass)
 
   object_class->dispose = cc_info_panel_dispose;
   object_class->finalize = cc_info_panel_finalize;
+  object_class->constructed = cc_info_panel_constructed;
 }
 
 static char *
@@ -1840,6 +1869,8 @@ cc_info_panel_init (CcInfoPanel *self)
       return;
     }
 
+  self->priv->hbox1 = WID ("hbox1");
+  self->priv->detail_vbox = WID ("detail_vbox");
   self->priv->updater_proxy = eos_updater_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
                                                                   G_DBUS_PROXY_FLAGS_NONE,
                                                                   "com.endlessm.Updater",

--- a/panels/mouse/cc-mouse-panel.c
+++ b/panels/mouse/cc-mouse-panel.c
@@ -84,7 +84,7 @@ cc_mouse_panel_constructed (GObject *object)
 {
   CcMousePanel *self = CC_MOUSE_PANEL (object);
   CcMousePanelPrivate *priv = self->priv;
-  GtkWidget *button, *container, *toplevel;
+  GtkWidget *button, *container, *toplevel, *label;
   CcShell *shell;
 
   G_OBJECT_CLASS (cc_mouse_panel_parent_class)->constructed (object);
@@ -92,7 +92,12 @@ cc_mouse_panel_constructed (GObject *object)
   /* Add test area button to shell header. */
   shell = cc_panel_get_shell (CC_PANEL (self));
 
-  button = gtk_button_new_with_mnemonic (_("Test Your _Settings"));
+  label = gtk_label_new_with_mnemonic (_("Test Your _Settings"));
+  gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
+  gtk_widget_show (label);
+
+  button = gtk_button_new ();
+  gtk_container_add (GTK_CONTAINER (button), label);
   gtk_style_context_add_class (gtk_widget_get_style_context (button),
                                "text-button");
   gtk_widget_set_valign (button, GTK_ALIGN_CENTER);

--- a/panels/mouse/gnome-mouse-properties.ui
+++ b/panels/mouse/gnome-mouse-properties.ui
@@ -59,7 +59,7 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">True</property>
+                        <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
@@ -76,9 +76,8 @@
                           <object class="GtkTable" id="table3">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="margin_right">220</property>
                             <property name="n_rows">2</property>
-                            <property name="n_columns">3</property>
+                            <property name="n_columns">2</property>
                             <property name="column_spacing">40</property>
                             <property name="row_spacing">10</property>
                             <child>
@@ -86,6 +85,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">5</property>
+                                <property name="halign">start</property>
                                 <child>
                                   <object class="GtkLabel" id="double_click_slow_label">
                                     <property name="visible">True</property>
@@ -109,6 +109,7 @@
                                     <property name="adjustment">adjustment4</property>
                                     <property name="inverted">True</property>
                                     <property name="draw_value">False</property>
+                                    <property name="width_request">100</property>
                                     <child internal-child="accessible">
                                       <object class="AtkObject" id="double_click_scale-atkobject">
                                         <property name="AtkObject::accessible-description" translatable="yes">Double-click timeout</property>
@@ -234,14 +235,14 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">True</property>
+                        <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
@@ -300,8 +301,7 @@
                           <object class="GtkTable" id="table2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="margin_right">220</property>
-                            <property name="n_columns">3</property>
+                            <property name="n_columns">2</property>
                             <property name="column_spacing">40</property>
                             <property name="row_spacing">5</property>
                             <child>
@@ -351,9 +351,10 @@
                                     <property name="adjustment">adjustment1</property>
                                     <property name="draw_value">False</property>
                                     <property name="value_pos">right</property>
+                                    <property name="width_request">100</property>
                                   </object>
                                   <packing>
-                                    <property name="expand">True</property>
+                                    <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="position">1</property>
                                   </packing>
@@ -485,8 +486,7 @@
                               <object class="GtkTable" id="table1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="margin_right">220</property>
-                                <property name="n_columns">3</property>
+                                <property name="n_columns">2</property>
                                 <property name="column_spacing">40</property>
                                 <property name="row_spacing">5</property>
                                 <child>
@@ -517,7 +517,6 @@
                                         <property name="can_focus">False</property>
                                         <property name="xalign">1</property>
                                         <property name="label" translatable="yes" context="touchpad pointer, speed">Slow</property>
-                                        <property name="justify">center</property>
                                         <attributes>
                                           <attribute name="scale" value="0.82999999999999996"/>
                                         </attributes>
@@ -535,9 +534,10 @@
                                         <property name="adjustment">adjustment11</property>
                                         <property name="draw_value">False</property>
                                         <property name="value_pos">right</property>
+                                        <property name="width_request">100</property>
                                       </object>
                                       <packing>
-                                        <property name="expand">True</property>
+                                        <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="position">1</property>
                                       </packing>

--- a/panels/privacy/cc-privacy-panel.c
+++ b/panels/privacy/cc-privacy-panel.c
@@ -162,6 +162,7 @@ add_row (CcPrivacyPanel *self,
   gtk_container_add (GTK_CONTAINER (self->priv->list_box), row);
 
   w = gtk_label_new (label);
+  gtk_label_set_line_wrap (GTK_LABEL (w), TRUE);
   gtk_misc_set_alignment (GTK_MISC (w), 0.0f, 0.5f);
   gtk_widget_set_margin_left (w, 20);
   gtk_widget_set_margin_right (w, 20);

--- a/panels/search/search.ui
+++ b/panels/search/search.ui
@@ -14,7 +14,7 @@
             <property name="shadow-type">in</property>
             <property name="vexpand">True</property>
             <property name="width-request">400</property>
-            <property name="height-request">350</property>
+            <property name="height-request">300</property>
           </object>
           <packing>
             <property name="expand">True</property>

--- a/panels/sound/cc-sound-panel.c
+++ b/panels/sound/cc-sound-panel.c
@@ -70,6 +70,33 @@ cc_sound_panel_set_property (GObject      *object,
         }
 }
 
+static void
+cc_sound_panel_constructed (GObject *object)
+{
+        CcSoundPanel *self = CC_SOUND_PANEL (object);
+        CcShell *shell;
+
+        shell = cc_panel_get_shell (CC_PANEL (self));
+
+        G_OBJECT_CLASS (cc_sound_panel_parent_class)->constructed (object);
+
+        if (cc_shell_is_small_screen (shell)) {
+                GtkWidget *sw;
+
+                g_object_ref (self->dialog);
+                gtk_container_remove (GTK_CONTAINER (self), GTK_WIDGET (self->dialog));
+
+                sw = gtk_scrolled_window_new (NULL, NULL);
+                gtk_scrolled_window_set_min_content_height (GTK_SCROLLED_WINDOW (sw), 400);
+                gtk_widget_show (sw);
+
+                gtk_container_add (GTK_CONTAINER (sw), GTK_WIDGET (self->dialog));
+                gtk_container_add (GTK_CONTAINER (self), sw);
+
+                g_object_unref (self->dialog);
+        }
+}
+
 static const char *
 cc_sound_panel_get_help_uri (CcPanel *panel)
 {
@@ -86,6 +113,7 @@ cc_sound_panel_class_init (CcSoundPanelClass *klass)
 
         object_class->finalize = cc_sound_panel_finalize;
         object_class->set_property = cc_sound_panel_set_property;
+        object_class->constructed = cc_sound_panel_constructed;
 
         g_object_class_override_property (object_class, PROP_PARAMETERS, "parameters");
 }

--- a/panels/universal-access/cc-ua-panel.c
+++ b/panels/universal-access/cc-ua-panel.c
@@ -86,7 +86,7 @@
 #define KEY_DWELL_TIME               "dwell-time"
 #define KEY_DWELL_THRESHOLD          "dwell-threshold"
 
-#define SCROLL_HEIGHT 490
+#define SCROLL_HEIGHT 400
 
 CC_PANEL_REGISTER (CcUaPanel, cc_ua_panel)
 

--- a/panels/user-accounts/um-user-panel.c
+++ b/panels/user-accounts/um-user-panel.c
@@ -1501,12 +1501,40 @@ cc_user_panel_get_help_uri (CcPanel *panel)
 }
 
 static void
+um_user_panel_constructed (GObject *object)
+{
+        CcUserPanel *self = UM_USER_PANEL (object);
+        CcShell *shell;
+
+        G_OBJECT_CLASS (cc_user_panel_parent_class)->constructed (object);
+
+        shell = cc_panel_get_shell (CC_PANEL (object));
+
+        /* Add scrollbars when screen is too small */
+        if (cc_shell_is_small_screen (shell)) {
+                GtkWidget *main_user_vbox, *hbox2, *sw;
+
+                sw = gtk_scrolled_window_new (NULL, NULL);
+                gtk_scrolled_window_set_min_content_width (GTK_SCROLLED_WINDOW (sw), 400);
+
+                main_user_vbox = get_widget (self->priv, "main-user-vbox");
+                hbox2 = get_widget (self->priv, "hbox2");
+                gtk_container_remove (GTK_CONTAINER (hbox2), main_user_vbox);
+                gtk_container_add (GTK_CONTAINER (sw), main_user_vbox);
+                gtk_container_add (GTK_CONTAINER (hbox2), sw);
+
+                gtk_widget_show (sw);
+        }
+}
+
+static void
 cc_user_panel_class_init (CcUserPanelClass *klass)
 {
         GObjectClass *object_class = G_OBJECT_CLASS (klass);
         CcPanelClass *panel_class = CC_PANEL_CLASS (klass);
 
         object_class->dispose = cc_user_panel_dispose;
+        object_class->constructed = um_user_panel_constructed;
 
         panel_class->get_permission = cc_user_panel_get_permission;
         panel_class->get_help_uri = cc_user_panel_get_help_uri;

--- a/shell/cc-shell-category-view.c
+++ b/shell/cc-shell-category-view.c
@@ -138,7 +138,6 @@ cc_shell_category_view_constructed (GObject *object)
   gtk_icon_view_set_text_column (GTK_ICON_VIEW (iconview), COL_NAME);
   gtk_icon_view_set_item_width (GTK_ICON_VIEW (iconview), 100);
   cc_shell_item_view_update_cells (CC_SHELL_ITEM_VIEW (iconview));
-  gtk_icon_view_set_columns (GTK_ICON_VIEW (iconview), 6);
 
   /* create the header if required */
   if (priv->name)

--- a/shell/cc-shell.c
+++ b/shell/cc-shell.c
@@ -171,3 +171,26 @@ cc_shell_embed_widget_in_header (CcShell *shell, GtkWidget *widget)
       iface->embed_widget_in_header (shell, widget);
     }
 }
+
+gboolean
+cc_shell_is_small_screen (CcShell *shell)
+{
+  CcShellInterface *iface;
+
+  g_return_if_fail (CC_IS_SHELL (shell));
+
+  iface = CC_SHELL_GET_IFACE (shell);
+
+  if (!iface->is_small_screen)
+    {
+      g_warning ("Object of type \"%s\" does not implement required interface"
+                 " method \"is_small_screen\",",
+                 G_OBJECT_TYPE_NAME (shell));
+    }
+  else
+    {
+      return iface->is_small_screen (shell);
+    }
+
+  return FALSE;
+}

--- a/shell/cc-shell.h
+++ b/shell/cc-shell.h
@@ -57,6 +57,7 @@ struct _CcShellInterface
   GtkWidget * (*get_toplevel)             (CcShell      *shell);
   void        (*embed_widget_in_header)   (CcShell      *shell,
                                            GtkWidget    *widget);
+  gboolean    (*is_small_screen)          (CcShell      *shell);
 };
 
 GType           cc_shell_get_type                 (void) G_GNUC_CONST;
@@ -72,6 +73,7 @@ GtkWidget *     cc_shell_get_toplevel             (CcShell      *shell);
 
 void            cc_shell_embed_widget_in_header   (CcShell      *shell,
                                                    GtkWidget    *widget);
+gboolean        cc_shell_is_small_screen          (CcShell      *shell);
 
 G_END_DECLS
 

--- a/shell/cc-window.c
+++ b/shell/cc-window.c
@@ -51,7 +51,7 @@ G_DEFINE_TYPE_WITH_CODE (CcWindow, cc_window, GTK_TYPE_APPLICATION_WINDOW,
  * for the user than resizing vertically
  * Both sizes are defined in https://live.gnome.org/Design/SystemSettings/ */
 #define FIXED_WIDTH 640
-#define FIXED_HEIGHT 636
+#define FIXED_HEIGHT 600
 #define SMALL_SCREEN_FIXED_HEIGHT 400
 
 #define MIN_ICON_VIEW_HEIGHT 300
@@ -116,6 +116,8 @@ static gboolean cc_window_set_active_panel_from_id (CcShell      *shell,
                                                     GError      **err);
 
 static gint get_monitor_height (CcWindow *self);
+
+static void update_small_screen_settings (CcWindow *self);
 
 static const gchar *
 get_icon_name_from_g_icon (GIcon *gicon)
@@ -1168,12 +1170,19 @@ cc_window_finalize (GObject *object)
   G_OBJECT_CLASS (cc_window_parent_class)->finalize (object);
 }
 
+static gboolean
+_shell_is_small_screen (CcShell *shell)
+{
+  return CC_WINDOW (shell)->priv->small_screen == SMALL_SCREEN_TRUE;
+}
+
 static void
 cc_shell_iface_init (CcShellInterface *iface)
 {
   iface->set_active_panel_from_id = _shell_set_active_panel_from_id;
   iface->embed_widget_in_header = _shell_embed_widget_in_header;
   iface->get_toplevel = _shell_get_toplevel;
+  iface->is_small_screen = _shell_is_small_screen;
 }
 
 static void

--- a/shell/cc-window.c
+++ b/shell/cc-window.c
@@ -50,7 +50,7 @@ G_DEFINE_TYPE_WITH_CODE (CcWindow, cc_window, GTK_TYPE_APPLICATION_WINDOW,
 /* Use a fixed width for the shell, since resizing horizontally is more awkward
  * for the user than resizing vertically
  * Both sizes are defined in https://live.gnome.org/Design/SystemSettings/ */
-#define FIXED_WIDTH 740
+#define FIXED_WIDTH 640
 #define FIXED_HEIGHT 636
 #define SMALL_SCREEN_FIXED_HEIGHT 400
 


### PR DESCRIPTION
This pull request solves the main issues with GNOME Control Center running on small screens. The changes:
- Don't make the number of columns in CategoryView class fixed to 6, so icons can adapt to different window sizes.
- Reduce the window's size request to 640, which is the smaller screen size we support.
- Adapt the panels so they don't request too much space.

[endlessm/eos-shell#6133]