### PR TITLE
window: set overview columns when screen size is big

### DIFF
--- a/panels/info/cc-info-panel.c
+++ b/panels/info/cc-info-panel.c
@@ -392,7 +392,7 @@ cc_info_panel_constructed (GObject *object)
       GtkWidget *sw;
 
       sw = gtk_scrolled_window_new (NULL, NULL);
-      gtk_scrolled_window_set_min_content_height (GTK_SCROLLED_WINDOW (sw), 380);
+      gtk_scrolled_window_set_min_content_height (GTK_SCROLLED_WINDOW (sw), 360);
 
       gtk_container_remove (GTK_CONTAINER (self->priv->hbox1), self->priv->detail_vbox);
       gtk_container_add (GTK_CONTAINER (sw), self->priv->detail_vbox);

--- a/panels/info/info.ui
+++ b/panels/info/info.ui
@@ -13,7 +13,6 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
@@ -208,7 +207,7 @@
                 </child>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>

--- a/shell/cc-window.c
+++ b/shell/cc-window.c
@@ -1334,6 +1334,7 @@ static void
 update_small_screen_settings (CcWindow *self)
 {
   CcSmallScreen small;
+  GList *item_views, *l;
 
   update_monitor_number (self);
   small = is_small (self);
@@ -1354,6 +1355,17 @@ update_small_screen_settings (CcWindow *self)
     }
 
   self->priv->small_screen = small;
+
+  /* If we're on a big screen, the icon view shall
+   * limit the number of columns to 6. Otherwise,
+   * make it adapt to small screen sizes.
+   */
+  item_views = get_item_views (self);
+
+  for (l = item_views; l != NULL; l = l->next)
+    gtk_icon_view_set_columns (l->data, small == SMALL_SCREEN_TRUE ? -1 : 6);
+
+  g_list_free (item_views);
 
   /* And update the minimum sizes */
   stack_page_notify_cb (GTK_STACK (self->priv->stack), NULL, self);


### PR DESCRIPTION
When the screen size is big enought, make the icon views from
the overview page set the number of columns to 6, imitating the
behavior we had before. When the screen size is small, unset the
number of columns, making it adapt to small screen sizes.

[endlessm/eos-shell#6133]