### PR TITLE
issue/6226

### DIFF
--- a/panels/network/connection-editor/connection-editor.ui
+++ b/panels/network/connection-editor/connection-editor.ui
@@ -56,6 +56,17 @@
           </packing>
         </child>
         <child>
+          <object class="GtkScrolledWindow" id="toplevel_scrolled_window">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hscrollbar_policy">never</property>
+            <property name="vscrollbar_policy">never</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="shadow_type">none</property>
+        <child>
           <object class="GtkNotebook" id="details_toplevel_notebook">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -188,6 +199,10 @@
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
+        </child>
+              </object>
+            </child>
+          </object>
         </child>
       </object>
     </child>

--- a/panels/network/connection-editor/net-connection-editor.c
+++ b/panels/network/connection-editor/net-connection-editor.c
@@ -21,6 +21,8 @@
 
 #include "config.h"
 
+#include <shell/cc-panel.h>
+
 #include <glib-object.h>
 #include <glib/gi18n.h>
 
@@ -157,6 +159,8 @@ net_connection_editor_init (NetConnectionEditor *editor)
                                                                 "details_page_list_selection"));
         g_signal_connect (selection, "changed",
                           G_CALLBACK (selection_changed), editor);
+
+        editor->scrolled_window = GTK_WIDGET (gtk_builder_get_object (editor->builder, "toplevel_scrolled_window"));
 }
 
 void
@@ -941,6 +945,18 @@ net_connection_editor_new (GtkWindow        *parent_window,
                 net_connection_editor_set_connection (editor, connection);
         else
                 net_connection_editor_add_connection (editor);
+
+        /* Show scrollbars when on low resolution displays */
+        if (CC_IS_SHELL (parent_window) && cc_shell_is_small_screen (CC_SHELL (parent_window))) {
+                gint width, height;
+
+                gtk_window_get_size (parent_window, &width, &height);
+                gtk_widget_set_size_request (editor->window, width, height);
+
+                gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (editor->scrolled_window),
+                                                GTK_POLICY_AUTOMATIC,
+                                                GTK_POLICY_AUTOMATIC);
+            }
 
         return editor;
 }

--- a/panels/network/connection-editor/net-connection-editor.h
+++ b/panels/network/connection-editor/net-connection-editor.h
@@ -45,6 +45,8 @@ struct _NetConnectionEditor
 {
          GObject parent;
 
+        GtkWidget        *scrolled_window;
+
         GtkWidget        *parent_window;
         NMClient         *client;
         NMDevice         *device;


### PR DESCRIPTION
When in small screens, the connection editor dialog
doesn't scale down to the screen size due to the
minimum width and height of it's children.

Fix that by adding a scrolled window that makes the
dialog scrollable when in small screens.

[endlessm/eos-shell#6226]