### PR TITLE
Issue/6226

### DIFF
--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -77,6 +77,8 @@ struct _CcNetworkPanelPrivate
         guint             nm_warning_idle;
         guint             refresh_idle;
 
+        GtkWidget        *scrolled_window;
+
         /* Killswitch stuff */
         GDBusProxy       *rfkill_proxy;
         GtkWidget        *kill_switch_header;
@@ -351,6 +353,7 @@ cc_network_panel_constructed (GObject *object)
         GtkWidget *box;
         GtkWidget *label;
         GtkWidget *widget;
+        CcShell *shell;
 
         G_OBJECT_CLASS (cc_network_panel_parent_class)->constructed (object);
 
@@ -383,6 +386,15 @@ cc_network_panel_constructed (GObject *object)
         g_signal_connect (panel->priv->rfkill_switch, "notify::active",
                           G_CALLBACK (cc_network_panel_notify_enable_active_cb),
                           panel);
+
+        /* Add scrollbars on small screens */
+        shell = cc_panel_get_shell (CC_PANEL (object));
+
+        if (cc_shell_is_small_screen (shell)) {
+                gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (panel->priv->scrolled_window),
+                                                GTK_POLICY_AUTOMATIC,
+                                                GTK_POLICY_AUTOMATIC);
+        }
 }
 
 static void
@@ -1373,6 +1385,9 @@ cc_network_panel_init (CcNetworkPanel *panel)
         }
 
         panel->priv->cancellable = g_cancellable_new ();
+
+        panel->priv->scrolled_window = GTK_WIDGET (gtk_builder_get_object (panel->priv->builder,
+                                                                           "content_scrolled_window"));
 
         panel->priv->treeview = GTK_WIDGET (gtk_builder_get_object (panel->priv->builder,
                                                                     "treeview_devices"));

--- a/panels/network/connection-editor/connection-editor.ui
+++ b/panels/network/connection-editor/connection-editor.ui
@@ -148,11 +148,13 @@
               <object class="GtkBox" id="details_add_connection_outer_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="vexpand">True</property>
                 <child>
                   <object class="GtkBox" id="details_add_connection_inner_box">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
+                    <property name="vexpand">True</property>
                     <child>
                       <object class="GtkFrame" id="details_add_connection_frame">
                         <property name="width_request">300</property>
@@ -160,12 +162,14 @@
                         <property name="can_focus">False</property>
                         <property name="label_xalign">0</property>
                         <property name="shadow_type">in</property>
+                        <property name="vexpand">True</property>
+                        <property name="valign">center</property>
                         <child>
                           <placeholder/>
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
+                        <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>

--- a/panels/network/network.ui
+++ b/panels/network/network.ui
@@ -173,16 +173,32 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkNotebook" id="notebook_types">
+                  <object class="GtkScrolledWindow" id="content_scrolled_window">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="show_border">False</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="hscrollbar_policy">never</property>
+                    <property name="vscrollbar_policy">never</property>
+                    <child>
+                      <object class="GtkViewport" id="content_viewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkNotebook" id="notebook_types">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="show_border">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/panels/printers/cc-printers-panel.c
+++ b/panels/printers/cc-printers-panel.c
@@ -106,6 +106,8 @@ struct _CcPrintersPanelPrivate
   GHashTable   *preferred_drivers;
   GCancellable *get_all_ppds_cancellable;
 
+  GtkWidget    *scrolled_window;
+
   gchar    *new_printer_name;
   gchar    *new_printer_location;
   gchar    *new_printer_make_and_model;
@@ -256,6 +258,24 @@ cc_printers_panel_get_help_uri (CcPanel *panel)
 }
 
 static void
+cc_printers_panel_constructed (GObject *object)
+{
+  CcPrintersPanelPrivate *priv = CC_PRINTERS_PANEL (object)->priv;
+  CcShell *shell;
+
+  G_OBJECT_CLASS (cc_printers_panel_parent_class)->constructed (object);
+
+  shell = cc_panel_get_shell (CC_PANEL (object));
+
+  if (cc_shell_is_small_screen (shell))
+    {
+      gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (priv->scrolled_window),
+                                      GTK_POLICY_AUTOMATIC,
+                                      GTK_POLICY_AUTOMATIC);
+    }
+}
+
+static void
 cc_printers_panel_class_init (CcPrintersPanelClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -265,6 +285,7 @@ cc_printers_panel_class_init (CcPrintersPanelClass *klass)
 
   object_class->get_property = cc_printers_panel_get_property;
   object_class->set_property = cc_printers_panel_set_property;
+  object_class->constructed = cc_printers_panel_constructed;
   object_class->dispose = cc_printers_panel_dispose;
   object_class->finalize = cc_printers_panel_finalize;
 
@@ -3013,6 +3034,9 @@ cc_printers_panel_init (CcPrintersPanel *self)
     gtk_builder_get_object (priv->builder, "printer-ip-address-label");
   cc_editable_entry_set_selectable (CC_EDITABLE_ENTRY (widget), TRUE);
 
+  /* Scrolled window */
+  priv->scrolled_window = (GtkWidget*)
+    gtk_builder_get_object (priv->builder, "scrolled-window");
 
   /* Add unlock button */
   priv->permission = (GPermission *)polkit_permission_new_sync (

--- a/panels/printers/printers.ui
+++ b/panels/printers/printers.ui
@@ -84,6 +84,17 @@
           </packing>
         </child>
         <child>
+          <object class="GtkScrolledWindow" id="scrolled-window">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hscrollbar_policy">never</property>
+            <property name="vscrollbar_policy">never</property>
+            <child>
+              <object class="GtkViewport" id="viewport">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="shadow_type">none</property>
+        <child>
           <object class="GtkNotebook" id="notebook">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -607,6 +618,10 @@ doesn't seem to be available.</property>
               </packing>
             </child>
           </object>
+          </child>
+        </object>
+      </child>
+    </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>


### PR DESCRIPTION
This PR fixes the following issues:

- The printer panel doesn't adapt to low resolution displays properly - fixed by adding scrollbars when in low resolution mode.
- Add Connection dialog UI is broken - fixed by expanding and vertically centering the connection list.
- Networks panel is too large - fixed by adding scrollbars when in low resolution mode.

[endlessm/eos-shell#6226]