### PR TITLE
panels: always expand vertically

### DIFF
--- a/shell/cc-panel.c
+++ b/shell/cc-panel.c
@@ -243,6 +243,8 @@ static void
 cc_panel_init (CcPanel *panel)
 {
   panel->priv = CC_PANEL_GET_PRIVATE (panel);
+
+  gtk_widget_set_vexpand (GTK_WIDGET (panel), TRUE);
 }
 
 /**


### PR DESCRIPTION
After the introduction of Gtk+ 3.20, many applications
had their UI broken because Gtk+ is more strict regarding
allocation now. The control center also suffers from this
side effect in various panels.

To fix that, make the broken panels expand vertically.

https://phabricator.endlessm.com/T11747