### PR TITLE
info: clear error before re-using it

### DIFF
--- a/panels/info/cc-info-panel.c
+++ b/panels/info/cc-info-panel.c
@@ -1805,7 +1805,7 @@ cc_info_panel_init (CcInfoPanel *self)
     {
       g_critical ("Unable to get a proxy to the EOS updater: %s. Updates will not be available.",
                   error->message);
-      g_error_free (error);
+      g_clear_error (&error);
     }
 
   self->priv->session_proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,


### PR DESCRIPTION
If the error is set here, it is an error to pass it to the code
initializing the session proxy.

https://phabricator.endlessm.com/T12564