### PR TITLE
power: Fix hiding wi-fi, mobile broadband toggles

### DIFF
--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -1834,7 +1834,6 @@ add_power_saving_section (CcPowerPanel *self)
                     G_CALLBACK (nm_device_changed), self);
   g_signal_connect (priv->nm_client, "device-removed",
                     G_CALLBACK (nm_device_changed), self);
-  nm_device_changed (priv->nm_client, NULL, self);
 
   g_signal_connect (G_OBJECT (priv->wifi_switch), "notify::active",
                     G_CALLBACK (wifi_switch_changed), self);
@@ -1891,6 +1890,10 @@ add_power_saving_section (CcPowerPanel *self)
 #endif
 
   gtk_widget_show_all (widget);
+
+#ifdef HAVE_NETWORK_MANAGER
+  nm_device_changed (priv->nm_client, NULL, self);
+#endif
 }
 
 static void


### PR DESCRIPTION
We check with NetworkManager whether a wireless device exists to decide
whether or not to display these toggles. NetworkManager says no, we hide
the toggles, then we call gtk_widget_show_all() and undo our work. Sad!
Actually pressing the toggles triggers the check again, and causes both
listbox rows to shockingly disappear.

This fix is not needed on the master branch because, since the port to
libnm 1.2, the check is now scheduled on the main loop, to run after
this function completes, inadvertantly fixing this bug.

https://bugzilla.gnome.org/show_bug.cgi?id=771148

(Note that commit message refers to the upstream master branch where this is fixed, but it's still needed on Endless master which is based off the upstream gnome-3-20 branch.)

https://phabricator.endlessm.com/T13205