### PR TITLE
power: Fix wifi device state when opening power panel

### DIFF
--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -1892,6 +1892,7 @@ add_power_saving_section (CcPowerPanel *self)
   gtk_widget_show_all (widget);
 
 #ifdef HAVE_NETWORK_MANAGER
+  nm_client_state_changed (priv->nm_client, NULL, self);
   nm_device_changed (priv->nm_client, NULL, self);
 #endif
 }


### PR DESCRIPTION
This toggle is always set to off when the panel is opened. We should
check whether it's on or not when opening the panel. Currently we are
only subscribed to changes, so we don't check the wifi state until it's
toggled on or off after the panel has been opened the first time.

https://bugzilla.gnome.org/show_bug.cgi?id=771564

https://phabricator.endlessm.com/T13205