### PR TITLE
display-panel: don't show overscan toggle when unsupported

### DIFF
--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -2561,7 +2561,8 @@ show_setup_dialog (CcDisplayPanel *panel)
     }
 
   /* overscan */
-  if (!gnome_rr_output_is_builtin_display (output))
+  if (!gnome_rr_output_is_builtin_display (output) &&
+      gnome_rr_output_supports_underscanning (output))
     {
       priv->scaling_check = gtk_check_button_new_with_label (_("Adjust screen for TV"));
       gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (priv->scaling_check),


### PR DESCRIPTION
When the overscan feature is not supported by the output, we
still show an useless checkbox that does nothing and has a high
potential to confuse users.

Fix that by only showing the checkbox when the overscan feature
is supported.

https://phabricator.endlessm.com/T13812