### PR TITLE
Allow defining branding-specific logos for the "info" panel.

### DIFF
--- a/panels/info/Makefile.am
+++ b/panels/info/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = 						\
 	$(INFO_PANEL_CFLAGS)				\
 	-DGNOMELOCALEDIR="\"$(datadir)/locale\""	\
 	-DDATADIR="\"$(datadir)\""			\
+	-DCONFIGDIR=\"$(sysconfdir)/$(PACKAGE)\" 	\
 	-DBINDIR="\"$(bindir)\""			\
 	$(NULL)
 


### PR DESCRIPTION
If a configuration file in /etc/eos-branding/gnome-control-center/info.conf
is found, it defines the path to a branding-specific logo and such a file
exists in disk, then gnome-control-center will use that one to override
Endless's logo in the "info" panel.

https://phabricator.endlessm.com/T15836