### PR TITLE
privacy: Update for PermissionStore DBus API changes

### DIFF
--- a/panels/privacy/cc-privacy-panel.c
+++ b/panels/privacy/cc-privacy-panel.c
@@ -814,9 +814,9 @@ add_location (CcPrivacyPanel *self)
   g_dbus_proxy_new_for_bus (G_BUS_TYPE_SESSION,
                             G_DBUS_PROXY_FLAGS_NONE,
                             NULL,
-                            "org.freedesktop.XdgApp",
-                            "/org/freedesktop/XdgApp/PermissionStore",
-                            "org.freedesktop.XdgApp.PermissionStore",
+                            "org.freedesktop.impl.portal.PermissionStore",
+                            "/org/freedesktop/impl/portal/PermissionStore",
+                            "org.freedesktop.impl.portal.PermissionStore",
                             priv->cancellable,
                             on_perm_store_ready,
                             self);


### PR DESCRIPTION
As xdg-app has been renamed to Flatpak, the permission store's bus name
and interface name have been changes as well.

https://bugzilla.gnome.org/show_bug.cgi?id=766603