### PR TITLE
user-accounts: Fix using the same label for set-password-on-login option

### DIFF
--- a/panels/user-accounts/data/password-dialog.ui
+++ b/panels/user-accounts/data/password-dialog.ui
@@ -234,7 +234,7 @@
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkRadioButton" id="action-login-radio">
-                        <property name="label" translatable="yes">Allow user to change their password on next _login</property>
+                        <property name="label" translatable="yes">Allow user to set a password when they next _login</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>


### PR DESCRIPTION
The labels for the the options of setting a password on their next log
in were mistakenly inconsistent.

https://phabricator.endlessm.com/T17270