### PR TITLE
cc-search-panel: ignore DefaultDisabled for Endless apps

### DIFF
--- a/panels/search/cc-search-panel.c
+++ b/panels/search/cc-search-panel.c
@@ -544,9 +544,16 @@ search_panel_add_one_provider (CcSearchPanel *self,
       goto out;
     }
 
+  /* Work around problem with all Endless flatpak apps accidentally
+     built with "DefaultDisabled=true" */
+  if (g_str_has_prefix (desktop_id, "com.endlessm."))
+    default_disabled = FALSE;
+  else
+    default_disabled = g_key_file_get_boolean (keyfile, SHELL_PROVIDER_GROUP,
+                                               "DefaultDisabled", NULL);
+
   g_free (desktop_id);
-  default_disabled = g_key_file_get_boolean (keyfile, SHELL_PROVIDER_GROUP,
-                                             "DefaultDisabled", NULL);
+
   search_panel_add_one_app_info (self, app_info, !default_disabled);
   g_object_unref (app_info);
 


### PR DESCRIPTION
Due to a bug in the flatpak builds, we have been accidentally
appending the search-provider.ini files with "DefaultDisabled=true".
This causes the default behavior for Endless apps to have
search disabled unless explicitly enabled in a gsetting.
Since global search of Endless apps is an important feature
of our OS, we include a hack here to pretend that Endless apps
(app ID starting with "com.endlessm.") do not set this flag.

While the proper fix is to fix the flatpak builder,
rebundle all Endless flatpaks, and update all Endless flatpaks
installed on user machines, that is a huge endeavor and not
something we can quickly patch, so we should live with this
hack for a while until we have fixed our latest flatpaks
and given users plenty of time to have updated all their apps.

We did not catch this bug in eos3.1 due to older shell code
in eos-desktop that did not check for this value.

https://phabricator.endlessm.com/T18082