### PR TITLE
debian/rules: check for conf files in /var/lib/eos-image-defaults

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ override_dh_auto_configure:
 		--libexecdir=\$${prefix}/lib/gnome-control-center \
 		--with-gnome-session-libexecdir=\$${prefix}/lib/gnome-session \
 		--disable-update-mimedb \
-		--with-vendor-conf-file=/var/eos-image-defaults/branding/gnome-control-center.conf
+		--with-vendor-conf-file=/var/lib/eos-image-defaults/branding/gnome-control-center.conf
 
 override_dh_install:
 	dh_install --list-missing


### PR DESCRIPTION
We intentionally moved the location of these files
from /var/eos-image-defaults to /var/lib/eos-image-defaults
but failed to update gnome-control-center accordingly.

https://phabricator.endlessm.com/T18935