### PR TITLE
Revert "display: pre-select output if there's only one"

### DIFF
--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -2657,30 +2657,6 @@ cc_display_panel_box_row_activated (GtkListBox     *listbox,
 }
 
 static void
-setup_initial_selection (CcDisplayPanel *panel)
-{
-  CcDisplayPanelPrivate *priv = panel->priv;
-  GnomeRROutputInfo **outputs;
-  gint i, num_connected_outputs = 0;
-
-  outputs = gnome_rr_config_get_outputs (priv->current_configuration);
-
-  /* count the number of active */
-  for (i = 0; outputs[i]; i++)
-    num_connected_outputs++;
-
-  /* If we only have one output, pop up the dialog right away */
-  if (num_connected_outputs == 1)
-    {
-      GtkListBoxRow *output_row;
-
-      output_row = gtk_list_box_get_row_at_index (GTK_LIST_BOX (priv->displays_listbox), 0);
-      cc_display_panel_box_row_activated (GTK_LIST_BOX (priv->displays_listbox),
-					  GTK_WIDGET (output_row), panel);
-    }
-}
-
-static void
 mapped_cb (CcDisplayPanel *panel)
 {
   CcDisplayPanelPrivate *priv = panel->priv;
@@ -2692,8 +2668,6 @@ mapped_cb (CcDisplayPanel *panel)
   if (toplevel)
     priv->focus_id = g_signal_connect (toplevel, "notify::has-toplevel-focus",
                                        G_CALLBACK (dialog_toplevel_focus_changed), panel);
-
-  setup_initial_selection (panel);
 }
 
 static void


### PR DESCRIPTION
This change is no longer a good idea now we also have the
"Night Light" option showing up in this panel.

This reverts commit 5ca23d62567ef3eba506466c9735029e5e0fe6eb.

https://phabricator.endlessm.com/T19358