### PR TITLE
Fix missing icon for mono speaker

### DIFF
--- a/panels/sound/data/icons/scalable/devices/Makefile.am
+++ b/panels/sound/data/icons/scalable/devices/Makefile.am
@@ -15,6 +15,8 @@ icons_DATA =					\
 	audio-speaker-left-side.svg		\
 	audio-speaker-left-side-testing.svg	\
 	audio-speaker-left-testing.svg		\
+	audio-speaker-mono.svg		\
+	audio-speaker-mono-testing.svg		\
 	audio-speaker-right-back.svg		\
 	audio-speaker-right-back-testing.svg	\
 	audio-speaker-right.svg			\

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-center-back-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-center-back-testing.svg
@@ -14,26 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.47 r22583"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-center-back-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-left-side-testing.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -364,30 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -399,19 +364,21 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:zoom="11.313708"
+     inkscape:cx="31.254917"
+     inkscape:cy="25.749564"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="977"
+     inkscape:window-width="3440"
+     inkscape:window-height="1376"
      inkscape:window-x="0"
      inkscape:window-y="27"
      showguides="false"
      inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
      inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
@@ -425,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -456,11 +417,9 @@
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
             <rdf:li>center</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-center-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -474,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(1,0,0,-1,-50.334601,47.958369)">
+       transform="matrix(1.2838284e-7,-2,-2,-1.2838284e-7,434.06251,122.00041)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="m 64.325669,10.506413 c 6.07143,-3.4821397 13.14286,-3.3928497 19.39286,0 l 2,4.39286 -23.39286,0 2,-4.39286 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.50000005;marker:none;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="m 95.897099,27.934983 c 0,0 -4.54743,-8.68677 -9.8613,-12.93926 -0.21063,-0.16856 -0.42247,-0.33016 -0.63527,-0.48397 -0.50204,-0.36286 -1.00946,-0.68239 -1.51919,-0.94787 -0.56896,-0.29634 -1.14078,-0.52533 -1.71117,-0.67205 -3.88321,-1.01934 -11.71652,-1.06249 -15.58966,-0.04613 -0.83989,0.21914 -1.6816,0.61173 -2.51203,1.13191 -0.62524,0.39166 -1.24409,0.85564 -1.85095,1.37236 -1.87112,1.5932 -3.628309,3.68784 -5.107769,5.71001 -2.59659,3.54911 -4.33766,6.875 -4.33766,6.875"
-         style="fill:none;stroke:none"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 62.827469,15.979023 2.18704,-4.766 c 5.261057,-2.7432797 11.220313,-3.3671697 17.939063,-0.0056 l 1.96851,4.2035"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="m 95.001579,28.523883 c 0,0 -6.30803,-12.92857 -13.07068,-14.66816 -3.88321,-1.01933 -11.18527,-1.06248 -15.05841,-0.04613 -6.84412,1.78572 -11.839659,12.46429 -11.839659,12.46429"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="m 43.214285,32.24107 c 0,2.736768 -9.374038,4.955357 -20.9375,4.955357 -11.563462,0 -20.9375001,-2.218589 -20.9375001,-4.955357 0,-2.736768 9.3740381,-4.955357 20.9375001,-4.955357 11.563462,0 20.9375,2.218589 20.9375,4.955357 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="m 95.16001,29.859216 c 0.1894,4.408221 -8.80985,9.066057 -20.909493,9.066057 -12.099643,0 -21.130461,-4.594701 -20.90949,-9.066057 -0.189403,-4.566056 8.809847,-9.034489 20.90949,-9.034489 12.099643,0 20.941063,4.37373 20.909493,9.034489 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 82.142459,27.943913 c -0.67407,2.18776 -3.2897,3.38538 -7.80786,3.38538 -4.51815,0 -7.3487,-1.37717 -7.80786,-3.38538 -0.07073,-1.70502 3.28971,-3.37359 7.80786,-3.37359 4.51816,0 7.81965,1.63321 7.80786,3.37359 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 67.476989,27.764793 c 0.9704,3.07926 3.66898,5.29604 6.84343,5.29605 3.19412,0 5.90648,-2.24438 6.86128,-5.35345 -0.90064,-1.50063 -4.28117,-2.23685 -6.89061,-2.19358 -3.30434,-0.08574 -5.85648,0.85968 -6.8141,2.25098 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 62.722179,14.847493 c -0.12704,0.1026 -0.3786,0.39515 -0.50465,0.50248 -1.87112,1.5932 -3.628309,3.68784 -5.107769,5.71001 -2.59659,3.54911 -4.33766,6.875 -4.33766,6.875 m 43.124999,0 c 0,0 -4.54743,-8.68677 -9.8613,-12.93926 -0.21063,-0.16856 -0.42247,-0.33016 -0.63527,-0.48397 -0.10052,-0.07265 -0.648157,-0.29253 -0.749077,-0.36162"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 81.930899,13.855723 c -3.88321,-1.01933 -11.18527,-1.06248 -15.05841,-0.04613"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000005;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-center-back.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-center-back.svg
@@ -14,7 +14,7 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.47 r22583"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-center-back.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
@@ -353,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -376,19 +364,21 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="-53.025818"
-     inkscape:cy="20.556657"
+     inkscape:zoom="11.313708"
+     inkscape:cx="31.254917"
+     inkscape:cy="25.749564"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="977"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
      inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
      inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
@@ -402,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -427,7 +419,7 @@
             <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-center</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -441,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="matrix(1,0,0,-1,-0.04163061,47.958369)">
+       transform="matrix(1.2838284e-7,-2,-2,-1.2838284e-7,434.06251,122.00041)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="m 14.032699,10.506413 c 6.07143,-3.4821397 13.14286,-3.3928497 19.39286,0 l 2,4.39286 -23.39286,0 2,-4.39286 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="m 45.604129,27.934983 c 0,0 -4.54743,-8.68677 -9.8613,-12.93926 -0.21063,-0.16856 -0.42247,-0.33016 -0.63527,-0.48397 -0.50204,-0.36286 -1.00946,-0.68239 -1.51919,-0.94787 -0.56896,-0.29634 -1.14078,-0.52533 -1.71117,-0.67205 -3.88321,-1.01934 -11.71652,-1.06249 -15.58966,-0.04613 -0.83989,0.21914 -1.6816,0.61173 -2.51203,1.13191 -0.62524,0.39166 -1.24409,0.85564 -1.85095,1.37236 -1.87112,1.5932 -3.6283094,3.68784 -5.1077694,5.71001 -2.59659,3.54911 -4.33766,6.875 -4.33766,6.875"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391027;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 12.534499,15.979023 2.18704,-4.766 c 5.261057,-2.7432797 11.220313,-3.3671697 17.939063,-0.0056 l 1.96851,4.2035"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391027;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="m 44.708609,28.523883 c 0,0 -6.30803,-12.92857 -13.07068,-14.66816 -3.88321,-1.01933 -11.18527,-1.06248 -15.05841,-0.04613 -6.8441198,1.78572 -11.8396594,12.46429 -11.8396594,12.46429"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="m 43.214285,32.24107 c 0,2.736768 -9.374038,4.955357 -20.9375,4.955357 -11.563462,0 -20.9375001,-2.218589 -20.9375001,-4.955357 0,-2.736768 9.3740381,-4.955357 20.9375001,-4.955357 11.563462,0 20.9375,2.218589 20.9375,4.955357 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 44.951119,29.943913 c 0.18941,4.40822 -8.80985,9.06606 -20.90949,9.06606 -12.09964,0 -21.1304594,-4.5947 -20.9094894,-9.06606 -0.1894,-4.56606 8.8098494,-9.03449 20.9094894,-9.03449 12.09964,0 20.94106,4.37373 20.90949,9.03449 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 31.849489,27.943913 c -0.67407,2.18776 -3.2897,3.38538 -7.80786,3.38538 -4.51815,0 -7.3487,-1.37717 -7.80786,-3.38538 -0.07073,-1.70502 3.28971,-3.37359 7.80786,-3.37359 4.51816,0 7.81965,1.63321 7.80786,3.37359 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 17.184019,27.764793 c 0.9704,3.07926 3.66898,5.29604 6.84343,5.29605 3.19412,0 5.90648,-2.24438 6.86128,-5.35345 -0.90064,-1.50063 -4.28117,-2.23685 -6.89061,-2.19358 -3.30434,-0.08574 -5.85648,0.85968 -6.8141,2.25098 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 12.429209,14.847493 c -0.12704,0.1026 -0.3786,0.39515 -0.50465,0.50248 -1.87112,1.5932 -3.6283094,3.68784 -5.1077694,5.71001 -2.59659,3.54911 -4.33766,6.875 -4.33766,6.875 m 43.1249994,0 c 0,0 -4.54743,-8.68677 -9.8613,-12.93926 -0.21063,-0.16856 -0.42247,-0.33016 -0.63527,-0.48397 -0.10052,-0.07265 -0.648157,-0.29253 -0.749077,-0.36162"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 31.637929,13.855723 c -3.88321,-1.01933 -11.18527,-1.06248 -15.05841,-0.04613"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.16391027;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-center.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-center.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,7 +14,7 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-center.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
@@ -352,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -375,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="-53.025818"
-     inkscape:cy="20.556657"
+     inkscape:zoom="8"
+     inkscape:cx="1.6296281"
+     inkscape:cy="-11.453638"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="25"
-     inkscape:window-y="21"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -400,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -439,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="translate(-4.1630606e-2,4.1631076e-2)">
+       transform="matrix(2.9261167e-8,2.0000002,-2.0000002,2.9261167e-8,434.06252,-74.000396)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="M 14.032699,10.506413 C 20.104129,7.0242733 27.175559,7.1135633 33.425559,10.506413 L 35.425559,14.899273 L 12.032699,14.899273 L 14.032699,10.506413 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 34.605519,14.148893 34.098099,13.829363 33.588369,13.563883 C 33.019409,13.267543 32.447589,13.038553 31.877199,12.891833 C 27.993989,11.872493 20.160679,11.829343 16.287539,12.845703 C 15.447649,13.064843 14.605939,13.457433 13.775509,13.977613 C 13.150269,14.369273 12.531419,14.833253 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391015;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 12.534499,15.979023 L 14.721539,11.213023 C 19.982596,8.4697433 25.941852,7.8458533 32.660602,11.207463 L 34.629112,15.410963"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391015;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 44.708609,28.523883 C 44.708609,28.523883 38.400579,15.595313 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593 C 9.7353992,15.595313 4.7398596,26.273883 4.7398596,26.273883"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 44.951119,29.943913 C 45.140529,34.352133 36.141269,39.009973 24.041629,39.009973 C 11.941989,39.009973 2.9111696,34.415273 3.1321396,29.943913 C 2.9427396,25.377853 11.941989,20.909423 24.041629,20.909423 C 36.141269,20.909423 44.982689,25.283153 44.951119,29.943913 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 31.849489,27.943913 C 31.175419,30.131673 28.559789,31.329293 24.041629,31.329293 C 19.523479,31.329293 16.692929,29.952123 16.233769,27.943913 C 16.163039,26.238893 19.523479,24.570323 24.041629,24.570323 C 28.559789,24.570323 31.861279,26.203533 31.849489,27.943913 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 17.184019,27.764793 C 18.154419,30.844053 20.852999,33.060833 24.027449,33.060843 C 27.221569,33.060843 29.933929,30.816463 30.888729,27.707393 C 29.988089,26.206763 26.607559,25.470543 23.998119,25.513813 C 20.693779,25.428073 18.141639,26.373493 17.184019,27.764793 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 12.429209,14.847493 C 12.302169,14.950093 12.050609,15.242643 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983 M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 35.007039,14.439103 34.459402,14.219223 34.358482,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.16391015;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-left-back-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-left-back-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,26 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-left-back-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-left-testing.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -363,30 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -398,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:zoom="8"
+     inkscape:cx="-2.4548513"
+     inkscape:cy="5.9299209"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="-12"
-     inkscape:window-y="0"
+     inkscape:window-width="3440"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -423,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -453,12 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>left-back</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-left-b-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -472,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(-0.7071068,-0.7071068,0.7071068,-0.7071068,57.052876,95.851156)">
+       transform="matrix(1.4142135,-1.4142137,1.4142137,1.4142135,-335.14805,-196.61703)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="M 64.325669,10.506413 C 70.397099,7.0242733 77.468529,7.1135633 83.718529,10.506413 L 85.718529,14.899273 L 62.325669,14.899273 L 64.325669,10.506413 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 84.898489,14.148893 84.391069,13.829363 83.881339,13.563883 C 83.312379,13.267543 82.740559,13.038553 82.170169,12.891833 C 78.286959,11.872493 70.453649,11.829343 66.580509,12.845703 C 65.740619,13.064843 64.898909,13.457433 64.068479,13.977613 C 63.443239,14.369273 62.824389,14.833253 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000004;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.827469,15.979023 L 65.014509,11.213023 C 70.275566,8.4697433 76.234822,7.8458533 82.953572,11.207463 L 84.922082,15.410963"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000004;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 95.001579,28.523883 C 95.001579,28.523883 88.693549,15.595313 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593 C 60.028369,15.595313 55.03283,26.273883 55.03283,26.273883"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="M 95.16001,29.859216 C 95.34941,34.267437 86.35016,38.925273 74.250517,38.925273 C 62.150874,38.925273 53.120056,34.330572 53.341027,29.859216 C 53.151624,25.29316 62.150874,20.824727 74.250517,20.824727 C 86.35016,20.824727 95.19158,25.198457 95.16001,29.859216 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 82.142459,27.943913 C 81.468389,30.131673 78.852759,31.329293 74.334599,31.329293 C 69.816449,31.329293 66.985899,29.952123 66.526739,27.943913 C 66.456009,26.238893 69.816449,24.570323 74.334599,24.570323 C 78.852759,24.570323 82.154249,26.203533 82.142459,27.943913 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 67.476989,27.764793 C 68.447389,30.844053 71.145969,33.060833 74.320419,33.060843 C 77.514539,33.060843 80.226899,30.816463 81.181699,27.707393 C 80.281059,26.206763 76.900529,25.470543 74.291089,25.513813 C 70.986749,25.428073 68.434609,26.373493 67.476989,27.764793 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 62.722179,14.847493 C 62.595139,14.950093 62.343579,15.242643 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983 M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 85.300009,14.439103 84.752372,14.219223 84.651452,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000004;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-left-back.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-left-back.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,11 +14,11 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-left-back.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-left.png"
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <defs
@@ -352,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -375,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="-53.376308"
-     inkscape:cy="20.556657"
+     inkscape:zoom="8"
+     inkscape:cx="-2.4548513"
+     inkscape:cy="5.9299209"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1601"
-     inkscape:window-height="942"
-     inkscape:window-x="5"
-     inkscape:window-y="1"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -400,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -422,10 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>left-back</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-left-back</dc:title>
+        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -439,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="matrix(-0.7071068,-0.7071068,0.7071068,-0.7071068,21.490375,60.288654)">
+       transform="matrix(1.4142135,-1.4142137,1.4142137,1.4142135,-335.14805,-196.61703)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="M 14.032699,10.506413 C 20.104129,7.0242733 27.175559,7.1135633 33.425559,10.506413 L 35.425559,14.899273 L 12.032699,14.899273 L 14.032699,10.506413 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 34.605519,14.148893 34.098099,13.829363 33.588369,13.563883 C 33.019409,13.267543 32.447589,13.038553 31.877199,12.891833 C 27.993989,11.872493 20.160679,11.829343 16.287539,12.845703 C 15.447649,13.064843 14.605939,13.457433 13.775509,13.977613 C 13.150269,14.369273 12.531419,14.833253 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 12.534499,15.979023 L 14.721539,11.213023 C 19.982596,8.4697433 25.941852,7.8458533 32.660602,11.207463 L 34.629112,15.410963"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 44.708609,28.523883 C 44.708609,28.523883 38.400579,15.595313 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593 C 9.7353992,15.595313 4.7398596,26.273883 4.7398596,26.273883"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 44.951119,29.943913 C 45.140529,34.352133 36.141269,39.009973 24.041629,39.009973 C 11.941989,39.009973 2.9111696,34.415273 3.1321396,29.943913 C 2.9427396,25.377853 11.941989,20.909423 24.041629,20.909423 C 36.141269,20.909423 44.982689,25.283153 44.951119,29.943913 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 31.849489,27.943913 C 31.175419,30.131673 28.559789,31.329293 24.041629,31.329293 C 19.523479,31.329293 16.692929,29.952123 16.233769,27.943913 C 16.163039,26.238893 19.523479,24.570323 24.041629,24.570323 C 28.559789,24.570323 31.861279,26.203533 31.849489,27.943913 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 17.184019,27.764793 C 18.154419,30.844053 20.852999,33.060833 24.027449,33.060843 C 27.221569,33.060843 29.933929,30.816463 30.888729,27.707393 C 29.988089,26.206763 26.607559,25.470543 23.998119,25.513813 C 20.693779,25.428073 18.141639,26.373493 17.184019,27.764793 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 12.429209,14.847493 C 12.302169,14.950093 12.050609,15.242643 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983 M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 35.007039,14.439103 34.459402,14.219223 34.358482,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.16391024;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-left-side-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-left-side-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,26 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-left-side-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-right-side-testing.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -363,30 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -398,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:zoom="11.313708"
+     inkscape:cx="9.5816545"
+     inkscape:cy="14.163095"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="-12"
-     inkscape:window-y="0"
+     inkscape:window-width="3440"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -423,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -453,12 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>left-side</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-left-side-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -472,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(0,-1,1,0,4.1631076e-2,98.334601)">
+       transform="matrix(2.0000001,-8.6649932e-8,8.6649932e-8,2.0000001,-73.937919,-386.00002)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="M 64.325669,10.506413 C 70.397099,7.0242733 77.468529,7.1135633 83.718529,10.506413 L 85.718529,14.899273 L 62.325669,14.899273 L 64.325669,10.506413 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 84.898489,14.148893 84.391069,13.829363 83.881339,13.563883 C 83.312379,13.267543 82.740559,13.038553 82.170169,12.891833 C 78.286959,11.872493 70.453649,11.829343 66.580509,12.845703 C 65.740619,13.064843 64.898909,13.457433 64.068479,13.977613 C 63.443239,14.369273 62.824389,14.833253 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.827469,15.979023 L 65.014509,11.213023 C 70.275566,8.4697433 76.234822,7.8458533 82.953572,11.207463 L 84.922082,15.410963"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 95.001579,28.523883 C 95.001579,28.523883 88.693549,15.595313 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593 C 60.028369,15.595313 55.03283,26.273883 55.03283,26.273883"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="M 95.16001,29.859216 C 95.34941,34.267437 86.35016,38.925273 74.250517,38.925273 C 62.150874,38.925273 53.120056,34.330572 53.341027,29.859216 C 53.151624,25.29316 62.150874,20.824727 74.250517,20.824727 C 86.35016,20.824727 95.19158,25.198457 95.16001,29.859216 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 82.142459,27.943913 C 81.468389,30.131673 78.852759,31.329293 74.334599,31.329293 C 69.816449,31.329293 66.985899,29.952123 66.526739,27.943913 C 66.456009,26.238893 69.816449,24.570323 74.334599,24.570323 C 78.852759,24.570323 82.154249,26.203533 82.142459,27.943913 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 67.476989,27.764793 C 68.447389,30.844053 71.145969,33.060833 74.320419,33.060843 C 77.514539,33.060843 80.226899,30.816463 81.181699,27.707393 C 80.281059,26.206763 76.900529,25.470543 74.291089,25.513813 C 70.986749,25.428073 68.434609,26.373493 67.476989,27.764793 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 62.722179,14.847493 C 62.595139,14.950093 62.343579,15.242643 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983 M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 85.300009,14.439103 84.752372,14.219223 84.651452,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000002;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-left-side.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-left-side.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,11 +14,11 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-left-side.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-left-side.png"
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <defs
@@ -352,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -375,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="-15.988037"
-     inkscape:cy="20.556657"
+     inkscape:zoom="11.313708"
+     inkscape:cx="20.01148"
+     inkscape:cy="-16.419273"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1601"
-     inkscape:window-height="942"
-     inkscape:window-x="5"
-     inkscape:window-y="1"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -400,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -422,10 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>left-side</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-left-side</dc:title>
+        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -439,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="matrix(0,-1,1,0,4.1631076e-2,48.041631)">
+       transform="matrix(2.0000001,-8.6649932e-8,8.6649932e-8,2.0000001,-73.937919,-386.00002)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="M 14.032699,10.506413 C 20.104129,7.0242733 27.175559,7.1135633 33.425559,10.506413 L 35.425559,14.899273 L 12.032699,14.899273 L 14.032699,10.506413 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 34.605519,14.148893 34.098099,13.829363 33.588369,13.563883 C 33.019409,13.267543 32.447589,13.038553 31.877199,12.891833 C 27.993989,11.872493 20.160679,11.829343 16.287539,12.845703 C 15.447649,13.064843 14.605939,13.457433 13.775509,13.977613 C 13.150269,14.369273 12.531419,14.833253 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391021;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 12.534499,15.979023 L 14.721539,11.213023 C 19.982596,8.4697433 25.941852,7.8458533 32.660602,11.207463 L 34.629112,15.410963"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391021;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 44.708609,28.523883 C 44.708609,28.523883 38.400579,15.595313 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593 C 9.7353992,15.595313 4.7398596,26.273883 4.7398596,26.273883"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 44.951119,29.943913 C 45.140529,34.352133 36.141269,39.009973 24.041629,39.009973 C 11.941989,39.009973 2.9111696,34.415273 3.1321396,29.943913 C 2.9427396,25.377853 11.941989,20.909423 24.041629,20.909423 C 36.141269,20.909423 44.982689,25.283153 44.951119,29.943913 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 31.849489,27.943913 C 31.175419,30.131673 28.559789,31.329293 24.041629,31.329293 C 19.523479,31.329293 16.692929,29.952123 16.233769,27.943913 C 16.163039,26.238893 19.523479,24.570323 24.041629,24.570323 C 28.559789,24.570323 31.861279,26.203533 31.849489,27.943913 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 17.184019,27.764793 C 18.154419,30.844053 20.852999,33.060833 24.027449,33.060843 C 27.221569,33.060843 29.933929,30.816463 30.888729,27.707393 C 29.988089,26.206763 26.607559,25.470543 23.998119,25.513813 C 20.693779,25.428073 18.141639,26.373493 17.184019,27.764793 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 12.429209,14.847493 C 12.302169,14.950093 12.050609,15.242643 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983 M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 35.007039,14.439103 34.459402,14.219223 34.358482,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.16391021;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-left-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-left-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,26 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-left-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-left-back-testing.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -363,30 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -398,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:zoom="11.313708"
+     inkscape:cx="80.640376"
+     inkscape:cy="35.349603"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="-12"
-     inkscape:window-y="0"
+     inkscape:window-width="3440"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -423,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -453,12 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>left</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-left-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -472,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(-0.7071068,0.7071068,0.7071068,0.7071068,57.052876,-47.851155)">
+       transform="matrix(1.4142137,1.4142136,-1.4142136,1.4142137,244.67953,-335.21055)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="M 64.325669,10.506413 C 70.397099,7.0242733 77.468529,7.1135633 83.718529,10.506413 L 85.718529,14.899273 L 62.325669,14.899273 L 64.325669,10.506413 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 84.898489,14.148893 84.391069,13.829363 83.881339,13.563883 C 83.312379,13.267543 82.740559,13.038553 82.170169,12.891833 C 78.286959,11.872493 70.453649,11.829343 66.580509,12.845703 C 65.740619,13.064843 64.898909,13.457433 64.068479,13.977613 C 63.443239,14.369273 62.824389,14.833253 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.827469,15.979023 L 65.014509,11.213023 C 70.275566,8.4697433 76.234822,7.8458533 82.953572,11.207463 L 84.922082,15.410963"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 95.001579,28.523883 C 95.001579,28.523883 88.693549,15.595313 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593 C 60.028369,15.595313 55.03283,26.273883 55.03283,26.273883"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="M 95.16001,29.859216 C 95.34941,34.267437 86.35016,38.925273 74.250517,38.925273 C 62.150874,38.925273 53.120056,34.330572 53.341027,29.859216 C 53.151624,25.29316 62.150874,20.824727 74.250517,20.824727 C 86.35016,20.824727 95.19158,25.198457 95.16001,29.859216 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 82.142459,27.943913 C 81.468389,30.131673 78.852759,31.329293 74.334599,31.329293 C 69.816449,31.329293 66.985899,29.952123 66.526739,27.943913 C 66.456009,26.238893 69.816449,24.570323 74.334599,24.570323 C 78.852759,24.570323 82.154249,26.203533 82.142459,27.943913 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 67.476989,27.764793 C 68.447389,30.844053 71.145969,33.060833 74.320419,33.060843 C 77.514539,33.060843 80.226899,30.816463 81.181699,27.707393 C 80.281059,26.206763 76.900529,25.470543 74.291089,25.513813 C 70.986749,25.428073 68.434609,26.373493 67.476989,27.764793 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 62.722179,14.847493 C 62.595139,14.950093 62.343579,15.242643 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983 M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 85.300009,14.439103 84.752372,14.219223 84.651452,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000002;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-left.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-left.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,11 +14,11 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-left.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-right.png"
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <defs
@@ -352,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -376,18 +365,21 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6568542"
-     inkscape:cx="-53.376308"
-     inkscape:cy="20.556657"
+     inkscape:cx="125.621"
+     inkscape:cy="44.778157"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1601"
-     inkscape:window-height="942"
-     inkscape:window-x="5"
-     inkscape:window-y="1"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -400,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -422,10 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>left</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-left</dc:title>
+        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -439,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="matrix(-0.7071068,0.7071068,0.7071068,0.7071068,21.490375,-12.288654)">
+       transform="matrix(1.4142137,1.4142136,-1.4142136,1.4142137,244.67953,-335.21055)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="M 14.032699,10.506413 C 20.104129,7.0242733 27.175559,7.1135633 33.425559,10.506413 L 35.425559,14.899273 L 12.032699,14.899273 L 14.032699,10.506413 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 34.605519,14.148893 34.098099,13.829363 33.588369,13.563883 C 33.019409,13.267543 32.447589,13.038553 31.877199,12.891833 C 27.993989,11.872493 20.160679,11.829343 16.287539,12.845703 C 15.447649,13.064843 14.605939,13.457433 13.775509,13.977613 C 13.150269,14.369273 12.531419,14.833253 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.1639102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 12.534499,15.979023 L 14.721539,11.213023 C 19.982596,8.4697433 25.941852,7.8458533 32.660602,11.207463 L 34.629112,15.410963"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.1639102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 44.708609,28.523883 C 44.708609,28.523883 38.400579,15.595313 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593 C 9.7353992,15.595313 4.7398596,26.273883 4.7398596,26.273883"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 44.951119,29.943913 C 45.140529,34.352133 36.141269,39.009973 24.041629,39.009973 C 11.941989,39.009973 2.9111696,34.415273 3.1321396,29.943913 C 2.9427396,25.377853 11.941989,20.909423 24.041629,20.909423 C 36.141269,20.909423 44.982689,25.283153 44.951119,29.943913 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 31.849489,27.943913 C 31.175419,30.131673 28.559789,31.329293 24.041629,31.329293 C 19.523479,31.329293 16.692929,29.952123 16.233769,27.943913 C 16.163039,26.238893 19.523479,24.570323 24.041629,24.570323 C 28.559789,24.570323 31.861279,26.203533 31.849489,27.943913 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 17.184019,27.764793 C 18.154419,30.844053 20.852999,33.060833 24.027449,33.060843 C 27.221569,33.060843 29.933929,30.816463 30.888729,27.707393 C 29.988089,26.206763 26.607559,25.470543 23.998119,25.513813 C 20.693779,25.428073 18.141639,26.373493 17.184019,27.764793 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 12.429209,14.847493 C 12.302169,14.950093 12.050609,15.242643 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983 M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 35.007039,14.439103 34.459402,14.219223 34.358482,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.1639102;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-mono-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-mono-testing.svg
@@ -16,7 +16,7 @@
    sodipodi:version="0.32"
    inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
-   sodipodi:docname="audio-speaker-center-testing.svg"
+   sodipodi:docname="audio-speaker-mono-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
@@ -364,17 +364,17 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="1.6296281"
-     inkscape:cy="-11.453638"
+     inkscape:zoom="1"
+     inkscape:cx="33.690885"
+     inkscape:cy="21.493021"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="3440"
-     inkscape:window-height="1376"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
      inkscape:guide-bbox="true"
      inkscape:showpageshadow="false"
@@ -432,44 +432,51 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1">
-    <g
-       transform="matrix(2.9261167e-8,2.0000002,-2.0000002,2.9261167e-8,434.06252,-74.000396)"
-       style="display:inline;stroke-width:0.5"
-       id="g8093"
-       inkscape:label="audio-volume-high">
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc"
-         id="path5491"
-         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
-      <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
-         id="rect6203"
-         width="16"
-         height="16"
-         x="41.000198"
-         y="197" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
-         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
-         id="rect11714-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
-         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
-         id="rect11703-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccscccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
-         mask="none"
-         clip-path="none"
-         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
-         id="path6297-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zccccccz" />
-    </g>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       d="m 48.002713,24 c -10e-7,5.628441 -2.000001,10.343459 -5.171142,14 H 40.00271 l 10e-7,-2.96144 C 42.532031,32 44.002713,28.59984 44.002713,24 c 0,-4.59984 -1.55906,-8 -3.999999,-11.03856 V 10 h 2.76256 c 2.931499,3.28088 5.237439,8.37156 5.237439,14 z"
+       id="rect11714-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       d="m 42.002714,23.999999 c -2e-6,4.333281 -1.477563,8.039641 -4.000003,10 l -2,10e-7 2e-6,-4 c 1.213041,-1.577559 1.999999,-3.517739 1.999999,-5.999999 10e-7,-2.482261 -0.78696,-4.43876 -1.999999,-6.000001 l 10e-7,-4 h 1.999999 c 2.445801,1.989561 4,5.7468 4.000001,9.999999 z"
+       id="rect11703-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       mask="none"
+       clip-path="none"
+       d="m 36.002712,24.000001 c 0,2.51466 -0.6233,4.43142 -1.999999,6 L 32.002711,30 l 1e-6,-6.000002 v -0.749999 l 2e-6,-5.249999 1.999999,-1e-6 c 1.344119,1.673801 1.999999,3.485341 1.999999,6.000002 z"
+       id="path6297-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zccccccz" />
+    <path
+       sodipodi:nodetypes="scccscccs"
+       inkscape:connector-curvature="0"
+       id="path21788"
+       d="m 0.065211,24 c 1e-6,5.628441 2.000001,10.343459 5.171142,14 h 2.828861 l -10e-7,-2.96144 C 5.535893,32 4.065211,28.59984 4.065211,24 c 0,-4.59984 1.55906,-8 3.999999,-11.03856 V 10 H 5.30265 C 2.371151,13.28088 0.065211,18.37156 0.065211,24 Z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="scccscccs"
+       inkscape:connector-curvature="0"
+       id="path21790"
+       d="m 6.06521,23.999999 c 2e-6,4.333281 1.477563,8.039641 4.000003,10 l 2,10e-7 -2e-6,-4 C 10.85217,28.422441 10.065212,26.482261 10.065212,24.000001 10.065211,21.51774 10.852172,19.561241 12.065211,18 l -10e-7,-4 h -1.999999 c -2.445801,1.989561 -4,5.7468 -4.000001,9.999999 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="zccccccz"
+       inkscape:connector-curvature="0"
+       id="path21792"
+       d="m 12.065212,24.000001 c 0,2.51466 0.6233,4.43142 1.999999,6 l 2.000002,-1e-6 -1e-6,-6.000002 V 23.249999 L 16.06521,18 l -1.999999,-1e-6 c -1.344119,1.673801 -1.999999,3.485341 -1.999999,6.000002 z"
+       clip-path="none"
+       mask="none"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;paint-order:normal"
+       id="path21794"
+       cx="24.019533"
+       cy="24.076326"
+       r="6.0216699" />
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-mono.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-mono.svg
@@ -16,7 +16,7 @@
    sodipodi:version="0.32"
    inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
-   sodipodi:docname="audio-speaker-center-testing.svg"
+   sodipodi:docname="audio-speaker-mono.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
@@ -364,17 +364,17 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="1.6296281"
-     inkscape:cy="-11.453638"
+     inkscape:zoom="1"
+     inkscape:cx="-2.75781"
+     inkscape:cy="0.79730978"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="3440"
-     inkscape:window-height="1376"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
      inkscape:guide-bbox="true"
      inkscape:showpageshadow="false"
@@ -432,44 +432,51 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1">
-    <g
-       transform="matrix(2.9261167e-8,2.0000002,-2.0000002,2.9261167e-8,434.06252,-74.000396)"
-       style="display:inline;stroke-width:0.5"
-       id="g8093"
-       inkscape:label="audio-volume-high">
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc"
-         id="path5491"
-         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
-      <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
-         id="rect6203"
-         width="16"
-         height="16"
-         x="41.000198"
-         y="197" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
-         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
-         id="rect11714-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
-         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
-         id="rect11703-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccscccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
-         mask="none"
-         clip-path="none"
-         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
-         id="path6297-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zccccccz" />
-    </g>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       d="m 48.002713,24 c -10e-7,5.628441 -2.000001,10.343459 -5.171142,14 H 40.00271 l 10e-7,-2.96144 C 42.532031,32 44.002713,28.59984 44.002713,24 c 0,-4.59984 -1.55906,-8 -3.999999,-11.03856 V 10 h 2.76256 c 2.931499,3.28088 5.237439,8.37156 5.237439,14 z"
+       id="rect11714-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       d="m 42.002714,23.999999 c -2e-6,4.333281 -1.477563,8.039641 -4.000003,10 l -2,10e-7 2e-6,-4 c 1.213041,-1.577559 1.999999,-3.517739 1.999999,-5.999999 10e-7,-2.482261 -0.78696,-4.43876 -1.999999,-6.000001 l 10e-7,-4 h 1.999999 c 2.445801,1.989561 4,5.7468 4.000001,9.999999 z"
+       id="rect11703-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       mask="none"
+       clip-path="none"
+       d="m 36.002712,24.000001 c 0,2.51466 -0.6233,4.43142 -1.999999,6 L 32.002711,30 l 1e-6,-6.000002 v -0.749999 l 2e-6,-5.249999 1.999999,-1e-6 c 1.344119,1.673801 1.999999,3.485341 1.999999,6.000002 z"
+       id="path6297-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zccccccz" />
+    <path
+       sodipodi:nodetypes="scccscccs"
+       inkscape:connector-curvature="0"
+       id="path21788"
+       d="m 0.065211,24 c 1e-6,5.628441 2.000001,10.343459 5.171142,14 h 2.828861 l -10e-7,-2.96144 C 5.535893,32 4.065211,28.59984 4.065211,24 c 0,-4.59984 1.55906,-8 3.999999,-11.03856 V 10 H 5.30265 C 2.371151,13.28088 0.065211,18.37156 0.065211,24 Z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="scccscccs"
+       inkscape:connector-curvature="0"
+       id="path21790"
+       d="m 6.06521,23.999999 c 2e-6,4.333281 1.477563,8.039641 4.000003,10 l 2,10e-7 -2e-6,-4 C 10.85217,28.422441 10.065212,26.482261 10.065212,24.000001 10.065211,21.51774 10.852172,19.561241 12.065211,18 l -10e-7,-4 h -1.999999 c -2.445801,1.989561 -4,5.7468 -4.000001,9.999999 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="zccccccz"
+       inkscape:connector-curvature="0"
+       id="path21792"
+       d="m 12.065212,24.000001 c 0,2.51466 0.6233,4.43142 1.999999,6 l 2.000002,-1e-6 -1e-6,-6.000002 V 23.249999 L 16.06521,18 l -1.999999,-1e-6 c -1.344119,1.673801 -1.999999,3.485341 -1.999999,6.000002 z"
+       clip-path="none"
+       mask="none"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;paint-order:normal"
+       id="path21794"
+       cx="24.019533"
+       cy="24.076326"
+       r="6.0216699" />
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-right-back-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-right-back-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,26 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-right-back-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-left-back-testing.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -363,30 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -398,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:zoom="11.313708"
+     inkscape:cx="-19.586532"
+     inkscape:cy="27.51471"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="-12"
-     inkscape:window-y="0"
+     inkscape:window-width="2027"
+     inkscape:window-height="1117"
+     inkscape:window-x="292"
+     inkscape:window-y="193"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="0">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -423,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -453,12 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>right-back</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-right-back-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -472,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(0.7071068,-0.7071068,-0.7071068,-0.7071068,-9.0528759,95.851156)">
+       transform="matrix(-1.4142135,-1.4142137,-1.4142137,1.4142135,383.27305,-196.61703)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="M 64.325669,10.506413 C 70.397099,7.0242733 77.468529,7.1135633 83.718529,10.506413 L 85.718529,14.899273 L 62.325669,14.899273 L 64.325669,10.506413 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 84.898489,14.148893 84.391069,13.829363 83.881339,13.563883 C 83.312379,13.267543 82.740559,13.038553 82.170169,12.891833 C 78.286959,11.872493 70.453649,11.829343 66.580509,12.845703 C 65.740619,13.064843 64.898909,13.457433 64.068479,13.977613 C 63.443239,14.369273 62.824389,14.833253 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000004;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.827469,15.979023 L 65.014509,11.213023 C 70.275566,8.4697433 76.234822,7.8458533 82.953572,11.207463 L 84.922082,15.410963"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000004;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 95.001579,28.523883 C 95.001579,28.523883 88.693549,15.595313 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593 C 60.028369,15.595313 55.03283,26.273883 55.03283,26.273883"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="M 95.16001,29.859216 C 95.34941,34.267437 86.35016,38.925273 74.250517,38.925273 C 62.150874,38.925273 53.120056,34.330572 53.341027,29.859216 C 53.151624,25.29316 62.150874,20.824727 74.250517,20.824727 C 86.35016,20.824727 95.19158,25.198457 95.16001,29.859216 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 82.142459,27.943913 C 81.468389,30.131673 78.852759,31.329293 74.334599,31.329293 C 69.816449,31.329293 66.985899,29.952123 66.526739,27.943913 C 66.456009,26.238893 69.816449,24.570323 74.334599,24.570323 C 78.852759,24.570323 82.154249,26.203533 82.142459,27.943913 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 67.476989,27.764793 C 68.447389,30.844053 71.145969,33.060833 74.320419,33.060843 C 77.514539,33.060843 80.226899,30.816463 81.181699,27.707393 C 80.281059,26.206763 76.900529,25.470543 74.291089,25.513813 C 70.986749,25.428073 68.434609,26.373493 67.476989,27.764793 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 62.722179,14.847493 C 62.595139,14.950093 62.343579,15.242643 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983 M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 85.300009,14.439103 84.752372,14.219223 84.651452,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000004;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-right-back.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-right-back.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,11 +14,11 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-right-back.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-left-back.png"
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <defs
@@ -352,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -375,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="-53.376308"
-     inkscape:cy="20.556657"
+     inkscape:zoom="11.313708"
+     inkscape:cx="-16.050998"
+     inkscape:cy="27.51471"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1601"
-     inkscape:window-height="942"
-     inkscape:window-x="5"
-     inkscape:window-y="1"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -400,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -422,10 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>right-back</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-right-back</dc:title>
+        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -439,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="matrix(0.7071068,-0.7071068,-0.7071068,-0.7071068,26.509625,60.288654)">
+       transform="matrix(-1.4142135,-1.4142137,-1.4142137,1.4142135,383.27305,-196.61703)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="M 14.032699,10.506413 C 20.104129,7.0242733 27.175559,7.1135633 33.425559,10.506413 L 35.425559,14.899273 L 12.032699,14.899273 L 14.032699,10.506413 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 34.605519,14.148893 34.098099,13.829363 33.588369,13.563883 C 33.019409,13.267543 32.447589,13.038553 31.877199,12.891833 C 27.993989,11.872493 20.160679,11.829343 16.287539,12.845703 C 15.447649,13.064843 14.605939,13.457433 13.775509,13.977613 C 13.150269,14.369273 12.531419,14.833253 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 12.534499,15.979023 L 14.721539,11.213023 C 19.982596,8.4697433 25.941852,7.8458533 32.660602,11.207463 L 34.629112,15.410963"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 44.708609,28.523883 C 44.708609,28.523883 38.400579,15.595313 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593 C 9.7353992,15.595313 4.7398596,26.273883 4.7398596,26.273883"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 44.951119,29.943913 C 45.140529,34.352133 36.141269,39.009973 24.041629,39.009973 C 11.941989,39.009973 2.9111696,34.415273 3.1321396,29.943913 C 2.9427396,25.377853 11.941989,20.909423 24.041629,20.909423 C 36.141269,20.909423 44.982689,25.283153 44.951119,29.943913 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 31.849489,27.943913 C 31.175419,30.131673 28.559789,31.329293 24.041629,31.329293 C 19.523479,31.329293 16.692929,29.952123 16.233769,27.943913 C 16.163039,26.238893 19.523479,24.570323 24.041629,24.570323 C 28.559789,24.570323 31.861279,26.203533 31.849489,27.943913 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 17.184019,27.764793 C 18.154419,30.844053 20.852999,33.060833 24.027449,33.060843 C 27.221569,33.060843 29.933929,30.816463 30.888729,27.707393 C 29.988089,26.206763 26.607559,25.470543 23.998119,25.513813 C 20.693779,25.428073 18.141639,26.373493 17.184019,27.764793 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 12.429209,14.847493 C 12.302169,14.950093 12.050609,15.242643 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983 M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 35.007039,14.439103 34.459402,14.219223 34.358482,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.16391024;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-right-side-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-right-side-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,26 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-right-side-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-right-back-testing.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -363,30 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -399,18 +365,21 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:cx="3.5728476"
+     inkscape:cy="54.167993"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="-12"
-     inkscape:window-y="0"
+     inkscape:window-width="3440"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -423,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -453,12 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>right-side</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-right-side-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -472,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(0,-1,-1,0,47.958369,98.334601)">
+       transform="matrix(-2.0000001,-8.6649932e-8,-8.6649932e-8,2.0000001,122.06292,-386.00002)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="M 64.325669,10.506413 C 70.397099,7.0242733 77.468529,7.1135633 83.718529,10.506413 L 85.718529,14.899273 L 62.325669,14.899273 L 64.325669,10.506413 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 84.898489,14.148893 84.391069,13.829363 83.881339,13.563883 C 83.312379,13.267543 82.740559,13.038553 82.170169,12.891833 C 78.286959,11.872493 70.453649,11.829343 66.580509,12.845703 C 65.740619,13.064843 64.898909,13.457433 64.068479,13.977613 C 63.443239,14.369273 62.824389,14.833253 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.827469,15.979023 L 65.014509,11.213023 C 70.275566,8.4697433 76.234822,7.8458533 82.953572,11.207463 L 84.922082,15.410963"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 95.001579,28.523883 C 95.001579,28.523883 88.693549,15.595313 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593 C 60.028369,15.595313 55.03283,26.273883 55.03283,26.273883"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="M 95.16001,29.859216 C 95.34941,34.267437 86.35016,38.925273 74.250517,38.925273 C 62.150874,38.925273 53.120056,34.330572 53.341027,29.859216 C 53.151624,25.29316 62.150874,20.824727 74.250517,20.824727 C 86.35016,20.824727 95.19158,25.198457 95.16001,29.859216 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 82.142459,27.943913 C 81.468389,30.131673 78.852759,31.329293 74.334599,31.329293 C 69.816449,31.329293 66.985899,29.952123 66.526739,27.943913 C 66.456009,26.238893 69.816449,24.570323 74.334599,24.570323 C 78.852759,24.570323 82.154249,26.203533 82.142459,27.943913 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 67.476989,27.764793 C 68.447389,30.844053 71.145969,33.060833 74.320419,33.060843 C 77.514539,33.060843 80.226899,30.816463 81.181699,27.707393 C 80.281059,26.206763 76.900529,25.470543 74.291089,25.513813 C 70.986749,25.428073 68.434609,26.373493 67.476989,27.764793 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 62.722179,14.847493 C 62.595139,14.950093 62.343579,15.242643 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983 M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 85.300009,14.439103 84.752372,14.219223 84.651452,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000002;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-right-side.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-right-side.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,11 +14,11 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-right-side.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-right-back.png"
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <defs
@@ -352,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -375,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="-15.988037"
-     inkscape:cy="20.556657"
+     inkscape:zoom="11.313708"
+     inkscape:cx="3.5728476"
+     inkscape:cy="54.167993"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1601"
-     inkscape:window-height="942"
-     inkscape:window-x="5"
-     inkscape:window-y="1"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -400,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -422,10 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>right-side</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-right-side</dc:title>
+        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -439,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="matrix(0,-1,-1,0,47.958369,48.041631)">
+       transform="matrix(-2.0000001,-8.6649932e-8,-8.6649932e-8,2.0000001,122.06292,-386.00002)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="M 14.032699,10.506413 C 20.104129,7.0242733 27.175559,7.1135633 33.425559,10.506413 L 35.425559,14.899273 L 12.032699,14.899273 L 14.032699,10.506413 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 34.605519,14.148893 34.098099,13.829363 33.588369,13.563883 C 33.019409,13.267543 32.447589,13.038553 31.877199,12.891833 C 27.993989,11.872493 20.160679,11.829343 16.287539,12.845703 C 15.447649,13.064843 14.605939,13.457433 13.775509,13.977613 C 13.150269,14.369273 12.531419,14.833253 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391021;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 12.534499,15.979023 L 14.721539,11.213023 C 19.982596,8.4697433 25.941852,7.8458533 32.660602,11.207463 L 34.629112,15.410963"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.16391021;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 44.708609,28.523883 C 44.708609,28.523883 38.400579,15.595313 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593 C 9.7353992,15.595313 4.7398596,26.273883 4.7398596,26.273883"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 44.951119,29.943913 C 45.140529,34.352133 36.141269,39.009973 24.041629,39.009973 C 11.941989,39.009973 2.9111696,34.415273 3.1321396,29.943913 C 2.9427396,25.377853 11.941989,20.909423 24.041629,20.909423 C 36.141269,20.909423 44.982689,25.283153 44.951119,29.943913 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 31.849489,27.943913 C 31.175419,30.131673 28.559789,31.329293 24.041629,31.329293 C 19.523479,31.329293 16.692929,29.952123 16.233769,27.943913 C 16.163039,26.238893 19.523479,24.570323 24.041629,24.570323 C 28.559789,24.570323 31.861279,26.203533 31.849489,27.943913 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 17.184019,27.764793 C 18.154419,30.844053 20.852999,33.060833 24.027449,33.060843 C 27.221569,33.060843 29.933929,30.816463 30.888729,27.707393 C 29.988089,26.206763 26.607559,25.470543 23.998119,25.513813 C 20.693779,25.428073 18.141639,26.373493 17.184019,27.764793 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 12.429209,14.847493 C 12.302169,14.950093 12.050609,15.242643 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983 M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 35.007039,14.439103 34.459402,14.219223 34.358482,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.16391021;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-right-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-right-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,226 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-right-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker-right-testing.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5941"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(11.322482,0,0,3.7410569,-790.12434,122.56351)"
-       cx="14.790665"
-       cy="29.860626"
-       fx="14.790665"
-       fy="29.860626"
-       r="1.1399525" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5939"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(10.171038,0,0,5.2502725,-797.43964,77.21735)"
-       cx="17.797972"
-       cy="29.948833"
-       fx="17.797972"
-       fy="29.948833"
-       r="1.945146" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient6377">
-      <stop
-         style="stop-color:#729fcf;stop-opacity:1"
-         offset="0"
-         id="stop6379" />
-      <stop
-         style="stop-color:#204a87;stop-opacity:1"
-         offset="1"
-         id="stop6381" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5937"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(15.4058,0,0,6.5714191,-930.81786,37.58535)"
-       cx="20.818829"
-       cy="29.948536"
-       fx="20.818829"
-       fy="29.948536"
-       r="2.5451017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5935"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,-677.47231,206.91558)"
-       x1="21.875"
-       y1="9.6335878"
-       x2="20.5"
-       y2="41.744865" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5933"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,-677.47231,206.91558)"
-       x1="20.087172"
-       y1="6.6629219"
-       x2="20.91938"
-       y2="38.337017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5931"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6831088,0,0,1.0329054,-652.67404,212.26374)"
-       x1="4.5961943"
-       y1="14.456622"
-       x2="4.5961943"
-       y2="30.313524" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5929"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7679166,0,0,1.687933,-652.72155,185.35433)"
-       x1="2.6850162"
-       y1="24.367676"
-       x2="2.9248238"
-       y2="35.053852" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient21582">
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0"
-         id="stop21584" />
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         offset="1"
-         id="stop21586" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21582"
-       id="linearGradient5927"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.2565202,-654.12827,206.16954)"
-       x1="21.875"
-       y1="26.625"
-       x2="18.187626"
-       y2="26" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient21598">
-      <stop
-         style="stop-color:white;stop-opacity:1;"
-         offset="0"
-         id="stop21600" />
-      <stop
-         style="stop-color:white;stop-opacity:0;"
-         offset="1"
-         id="stop21602" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21598"
-       id="linearGradient5925"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7830101,0,0,0.9810567,-652.01527,212.32101)"
-       x1="12.25"
-       y1="19.75"
-       x2="10.875"
-       y2="33.125" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="radialGradient5923"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.433087,-0.596698,0.798238,1.917124,-20.96864,-16.43019)"
-       cx="7.001297"
-       cy="22.470087"
-       fx="7.001297"
-       fy="22.470087"
-       r="6.4940691" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10872"
-       id="linearGradient5921"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.0172401,-654.21562,212.46274)"
-       x1="3.8890872"
-       y1="18.937069"
-       x2="3.8890872"
-       y2="25.947107" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5919"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,-655.42965,207.54612)"
-       x1="11.875"
-       y1="20.375"
-       x2="13.125"
-       y2="34.13559" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6371"
-       id="linearGradient5917"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,-655.42965,207.54612)"
-       x1="14.241117"
-       y1="26.996773"
-       x2="15.125"
-       y2="20.976084" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21608"
-       id="linearGradient5915"
-       gradientUnits="userSpaceOnUse"
-       x1="23.272787"
-       y1="18.525478"
-       x2="23.272787"
-       y2="22.811184" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient15341"
-       id="radialGradient5913"
-       gradientUnits="userSpaceOnUse"
-       cx="22.624176"
-       cy="20.880224"
-       fx="22.624176"
-       fy="20.880224"
-       r="3.3177083" />
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3529"
-       id="radialGradient5911"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.2876712,0,13.845354)"
-       cx="7.9549513"
-       cy="19.436747"
-       fx="7.9549513"
-       fy="19.436747"
-       r="6.4523492" />
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -563,206 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3529"
-       id="radialGradient5708"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.2876712,0,13.845354)"
-       cx="7.9549513"
-       cy="19.436747"
-       fx="7.9549513"
-       fy="19.436747"
-       r="6.4523492" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient15341"
-       id="radialGradient5710"
-       gradientUnits="userSpaceOnUse"
-       cx="22.624176"
-       cy="20.880224"
-       fx="22.624176"
-       fy="20.880224"
-       r="3.3177083" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21608"
-       id="linearGradient5712"
-       gradientUnits="userSpaceOnUse"
-       x1="23.272787"
-       y1="18.525478"
-       x2="23.272787"
-       y2="22.811184" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="radialGradient5720"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.433087,-0.596698,0.798238,1.917124,-20.96864,-16.43019)"
-       cx="7.001297"
-       cy="22.470087"
-       fx="7.001297"
-       fy="22.470087"
-       r="6.4940691" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5744"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-8.0062038,8.0062038,-2.6453267,-2.6453267,292.61535,-42.156174)"
-       cx="14.790665"
-       cy="29.860626"
-       fx="14.790665"
-       fy="29.860626"
-       r="1.1399525" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5747"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-7.1920099,7.1920099,-3.7125033,-3.7125033,329.85262,-15.264295)"
-       cx="17.797972"
-       cy="29.948833"
-       fx="17.797972"
-       fy="29.948833"
-       r="1.945146" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5750"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-10.893546,10.893546,-4.646695,-4.646695,452.18932,-81.552883)"
-       cx="20.818829"
-       cy="29.948536"
-       fx="20.818829"
-       fy="29.948536"
-       r="2.5451017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5753"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,31.77769,-26.9466)"
-       x1="20.087172"
-       y1="6.6629219"
-       x2="20.91938"
-       y2="38.337017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5755"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,31.77769,-26.9466)"
-       x1="21.875"
-       y1="9.6335878"
-       x2="20.5"
-       y2="41.744865" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5758"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7679166,0,0,1.687933,56.52845,-48.50785)"
-       x1="2.6850162"
-       y1="24.367676"
-       x2="2.9248238"
-       y2="35.053852" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5760"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6831088,0,0,1.0329054,56.57596,-21.59844)"
-       x1="4.5961943"
-       y1="14.456622"
-       x2="4.5961943"
-       y2="30.313524" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21582"
-       id="linearGradient5763"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.2565202,55.12173,-27.69264)"
-       x1="21.875"
-       y1="26.625"
-       x2="18.187626"
-       y2="26" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21598"
-       id="linearGradient5766"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7830101,0,0,0.9810567,57.23473,-21.54117)"
-       x1="12.25"
-       y1="19.75"
-       x2="10.875"
-       y2="33.125" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10872"
-       id="linearGradient5770"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.0172401,55.03438,-21.39944)"
-       x1="3.8890872"
-       y1="18.937069"
-       x2="3.8890872"
-       y2="25.947107" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6371"
-       id="linearGradient5773"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,53.82035,-26.31606)"
-       x1="14.241117"
-       y1="26.996773"
-       x2="15.125"
-       y2="20.976084" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5775"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,53.82035,-26.31606)"
-       x1="11.875"
-       y1="20.375"
-       x2="13.125"
-       y2="34.13559" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient5928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -775,18 +365,21 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:cx="10.22266"
+     inkscape:cy="32.058291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="-12"
-     inkscape:window-y="0"
+     inkscape:window-width="3440"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -799,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -829,12 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>right</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-right-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -848,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(0.7071068,0.7071068,-0.7071068,0.7071068,-9.0528759,-47.851156)">
+       transform="matrix(-1.4142137,1.4142136,1.4142136,1.4142137,-196.55454,-335.21055)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="M 64.325669,10.506413 C 70.397099,7.0242733 77.468529,7.1135633 83.718529,10.506413 L 85.718529,14.899273 L 62.325669,14.899273 L 64.325669,10.506413 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 84.898489,14.148893 84.391069,13.829363 83.881339,13.563883 C 83.312379,13.267543 82.740559,13.038553 82.170169,12.891833 C 78.286959,11.872493 70.453649,11.829343 66.580509,12.845703 C 65.740619,13.064843 64.898909,13.457433 64.068479,13.977613 C 63.443239,14.369273 62.824389,14.833253 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.827469,15.979023 L 65.014509,11.213023 C 70.275566,8.4697433 76.234822,7.8458533 82.953572,11.207463 L 84.922082,15.410963"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 95.001579,28.523883 C 95.001579,28.523883 88.693549,15.595313 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593 C 60.028369,15.595313 55.03283,26.273883 55.03283,26.273883"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="M 95.16001,29.859216 C 95.34941,34.267437 86.35016,38.925273 74.250517,38.925273 C 62.150874,38.925273 53.120056,34.330572 53.341027,29.859216 C 53.151624,25.29316 62.150874,20.824727 74.250517,20.824727 C 86.35016,20.824727 95.19158,25.198457 95.16001,29.859216 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 82.142459,27.943913 C 81.468389,30.131673 78.852759,31.329293 74.334599,31.329293 C 69.816449,31.329293 66.985899,29.952123 66.526739,27.943913 C 66.456009,26.238893 69.816449,24.570323 74.334599,24.570323 C 78.852759,24.570323 82.154249,26.203533 82.142459,27.943913 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 67.476989,27.764793 C 68.447389,30.844053 71.145969,33.060833 74.320419,33.060843 C 77.514539,33.060843 80.226899,30.816463 81.181699,27.707393 C 80.281059,26.206763 76.900529,25.470543 74.291089,25.513813 C 70.986749,25.428073 68.434609,26.373493 67.476989,27.764793 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 62.722179,14.847493 C 62.595139,14.950093 62.343579,15.242643 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983 M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 85.300009,14.439103 84.752372,14.219223 84.651452,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000002;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-right.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-right.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,7 +14,7 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-speaker-right.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
@@ -352,18 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient7260"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.516569,40.378763)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -375,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="-90.590866"
-     inkscape:cy="20.556657"
+     inkscape:zoom="16"
+     inkscape:cx="23.91016"
+     inkscape:cy="-4.8792089"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1601"
-     inkscape:window-height="942"
-     inkscape:window-x="5"
-     inkscape:window-y="1"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -400,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -422,10 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>right</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-right</dc:title>
+        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -439,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g7248"
-       transform="matrix(0.7071068,0.7071068,-0.7071068,0.7071068,26.509625,-12.288654)">
+       transform="matrix(-1.4142137,1.4142136,1.4142136,1.4142137,-196.55454,-335.21055)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path5365"
-         d="M 14.032699,10.506413 C 20.104129,7.0242733 27.175559,7.1135633 33.425559,10.506413 L 35.425559,14.899273 L 12.032699,14.899273 L 14.032699,10.506413 z"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 34.605519,14.148893 34.098099,13.829363 33.588369,13.563883 C 33.019409,13.267543 32.447589,13.038553 31.877199,12.891833 C 27.993989,11.872493 20.160679,11.829343 16.287539,12.845703 C 15.447649,13.064843 14.605939,13.457433 13.775509,13.977613 C 13.150269,14.369273 12.531419,14.833253 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983"
-         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5367" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.1639102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#888a83;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 12.534499,15.979023 L 14.721539,11.213023 C 19.982596,8.4697433 25.941852,7.8458533 32.660602,11.207463 L 34.629112,15.410963"
-         id="path5369"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:1.1639102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 44.708609,28.523883 C 44.708609,28.523883 38.400579,15.595313 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593 C 9.7353992,15.595313 4.7398596,26.273883 4.7398596,26.273883"
-         style="fill:#555753;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path5371" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,0.7198796,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path5373"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:url(#radialGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 44.951119,29.943913 C 45.140529,34.352133 36.141269,39.009973 24.041629,39.009973 C 11.941989,39.009973 2.9111696,34.415273 3.1321396,29.943913 C 2.9427396,25.377853 11.941989,20.909423 24.041629,20.909423 C 36.141269,20.909423 44.982689,25.283153 44.951119,29.943913 z"
-         id="path5375"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 31.849489,27.943913 C 31.175419,30.131673 28.559789,31.329293 24.041629,31.329293 C 19.523479,31.329293 16.692929,29.952123 16.233769,27.943913 C 16.163039,26.238893 19.523479,24.570323 24.041629,24.570323 C 28.559789,24.570323 31.861279,26.203533 31.849489,27.943913 z"
-         id="path5377"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 17.184019,27.764793 C 18.154419,30.844053 20.852999,33.060833 24.027449,33.060843 C 27.221569,33.060843 29.933929,30.816463 30.888729,27.707393 C 29.988089,26.206763 26.607559,25.470543 23.998119,25.513813 C 20.693779,25.428073 18.141639,26.373493 17.184019,27.764793 z"
-         id="path5379"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path5381"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 12.429209,14.847493 C 12.302169,14.950093 12.050609,15.242643 11.924559,15.349973 C 10.053439,16.943173 8.2962496,19.037813 6.8167896,21.059983 C 4.2201996,24.609093 2.4791296,27.934983 2.4791296,27.934983 M 45.604129,27.934983 C 45.604129,27.934983 41.056699,19.248213 35.742829,14.995723 C 35.532199,14.827163 35.320359,14.665563 35.107559,14.511753 C 35.007039,14.439103 34.459402,14.219223 34.358482,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path5383"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 31.637929,13.855723 C 27.754719,12.836393 20.452659,12.793243 16.579519,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:1.1639102;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-speaker-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-speaker-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,226 +14,15 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
-   sodipodi:docname="audio-speaker-testing.svg"
+   sodipodi:docname="audio-speaker-right-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_speaker.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5941"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(11.322482,0,0,3.7410569,-790.12434,122.56351)"
-       cx="14.790665"
-       cy="29.860626"
-       fx="14.790665"
-       fy="29.860626"
-       r="1.1399525" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5939"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(10.171038,0,0,5.2502725,-797.43964,77.21735)"
-       cx="17.797972"
-       cy="29.948833"
-       fx="17.797972"
-       fy="29.948833"
-       r="1.945146" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient6377">
-      <stop
-         style="stop-color:#729fcf;stop-opacity:1"
-         offset="0"
-         id="stop6379" />
-      <stop
-         style="stop-color:#204a87;stop-opacity:1"
-         offset="1"
-         id="stop6381" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5937"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(15.4058,0,0,6.5714191,-930.81786,37.58535)"
-       cx="20.818829"
-       cy="29.948536"
-       fx="20.818829"
-       fy="29.948536"
-       r="2.5451017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5935"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,-677.47231,206.91558)"
-       x1="21.875"
-       y1="9.6335878"
-       x2="20.5"
-       y2="41.744865" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5933"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,-677.47231,206.91558)"
-       x1="20.087172"
-       y1="6.6629219"
-       x2="20.91938"
-       y2="38.337017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5931"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6831088,0,0,1.0329054,-652.67404,212.26374)"
-       x1="4.5961943"
-       y1="14.456622"
-       x2="4.5961943"
-       y2="30.313524" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5929"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7679166,0,0,1.687933,-652.72155,185.35433)"
-       x1="2.6850162"
-       y1="24.367676"
-       x2="2.9248238"
-       y2="35.053852" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient21582">
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0"
-         id="stop21584" />
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         offset="1"
-         id="stop21586" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21582"
-       id="linearGradient5927"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.2565202,-654.12827,206.16954)"
-       x1="21.875"
-       y1="26.625"
-       x2="18.187626"
-       y2="26" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient21598">
-      <stop
-         style="stop-color:white;stop-opacity:1;"
-         offset="0"
-         id="stop21600" />
-      <stop
-         style="stop-color:white;stop-opacity:0;"
-         offset="1"
-         id="stop21602" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21598"
-       id="linearGradient5925"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7830101,0,0,0.9810567,-652.01527,212.32101)"
-       x1="12.25"
-       y1="19.75"
-       x2="10.875"
-       y2="33.125" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="radialGradient5923"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.433087,-0.596698,0.798238,1.917124,-20.96864,-16.43019)"
-       cx="7.001297"
-       cy="22.470087"
-       fx="7.001297"
-       fy="22.470087"
-       r="6.4940691" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10872"
-       id="linearGradient5921"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.0172401,-654.21562,212.46274)"
-       x1="3.8890872"
-       y1="18.937069"
-       x2="3.8890872"
-       y2="25.947107" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5919"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,-655.42965,207.54612)"
-       x1="11.875"
-       y1="20.375"
-       x2="13.125"
-       y2="34.13559" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6371"
-       id="linearGradient5917"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,-655.42965,207.54612)"
-       x1="14.241117"
-       y1="26.996773"
-       x2="15.125"
-       y2="20.976084" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21608"
-       id="linearGradient5915"
-       gradientUnits="userSpaceOnUse"
-       x1="23.272787"
-       y1="18.525478"
-       x2="23.272787"
-       y2="22.811184" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient15341"
-       id="radialGradient5913"
-       gradientUnits="userSpaceOnUse"
-       cx="22.624176"
-       cy="20.880224"
-       fx="22.624176"
-       fy="20.880224"
-       r="3.3177083" />
-    <linearGradient
-       id="linearGradient3529">
-      <stop
-         id="stop3531"
-         offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
-      <stop
-         id="stop3533"
-         offset="1"
-         style="stop-color:#e8e7e6;stop-opacity:1;" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3529"
-       id="radialGradient5911"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.2876712,0,13.845354)"
-       cx="7.9549513"
-       cy="19.436747"
-       fx="7.9549513"
-       fy="19.436747"
-       r="6.4523492" />
     <linearGradient
        id="linearGradient4389">
       <stop
@@ -563,206 +353,6 @@
        fx="22.276297"
        fy="21.099283"
        r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3345"
-       id="radialGradient5554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.725459,40.419065)"
-       spreadMethod="pad"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient8512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3529"
-       id="radialGradient5708"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.2876712,0,13.845354)"
-       cx="7.9549513"
-       cy="19.436747"
-       fx="7.9549513"
-       fy="19.436747"
-       r="6.4523492" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient15341"
-       id="radialGradient5710"
-       gradientUnits="userSpaceOnUse"
-       cx="22.624176"
-       cy="20.880224"
-       fx="22.624176"
-       fy="20.880224"
-       r="3.3177083" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21608"
-       id="linearGradient5712"
-       gradientUnits="userSpaceOnUse"
-       x1="23.272787"
-       y1="18.525478"
-       x2="23.272787"
-       y2="22.811184" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="radialGradient5720"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.433087,-0.596698,0.798238,1.917124,-20.96864,-16.43019)"
-       cx="7.001297"
-       cy="22.470087"
-       fx="7.001297"
-       fy="22.470087"
-       r="6.4940691" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5744"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-8.0062038,8.0062038,-2.6453267,-2.6453267,292.61535,-42.156174)"
-       cx="14.790665"
-       cy="29.860626"
-       fx="14.790665"
-       fy="29.860626"
-       r="1.1399525" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5747"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-7.1920099,7.1920099,-3.7125033,-3.7125033,329.85262,-15.264295)"
-       cx="17.797972"
-       cy="29.948833"
-       fx="17.797972"
-       fy="29.948833"
-       r="1.945146" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6377"
-       id="radialGradient5750"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-10.893546,10.893546,-4.646695,-4.646695,452.18932,-81.552883)"
-       cx="20.818829"
-       cy="29.948536"
-       fx="20.818829"
-       fy="29.948536"
-       r="2.5451017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5753"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,31.77769,-26.9466)"
-       x1="20.087172"
-       y1="6.6629219"
-       x2="20.91938"
-       y2="38.337017" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5755"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0714931,0,0,1.2212999,31.77769,-26.9466)"
-       x1="21.875"
-       y1="9.6335878"
-       x2="20.5"
-       y2="41.744865" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10055"
-       id="linearGradient5758"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7679166,0,0,1.687933,56.52845,-48.50785)"
-       x1="2.6850162"
-       y1="24.367676"
-       x2="2.9248238"
-       y2="35.053852" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5760"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6831088,0,0,1.0329054,56.57596,-21.59844)"
-       x1="4.5961943"
-       y1="14.456622"
-       x2="4.5961943"
-       y2="30.313524" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21582"
-       id="linearGradient5763"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.2565202,55.12173,-27.69264)"
-       x1="21.875"
-       y1="26.625"
-       x2="18.187626"
-       y2="26" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient21598"
-       id="linearGradient5766"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7830101,0,0,0.9810567,57.23473,-21.54117)"
-       x1="12.25"
-       y1="19.75"
-       x2="10.875"
-       y2="33.125" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10872"
-       id="linearGradient5770"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0102994,0,0,1.0172401,55.03438,-21.39944)"
-       x1="3.8890872"
-       y1="18.937069"
-       x2="3.8890872"
-       y2="25.947107" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6371"
-       id="linearGradient5773"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,53.82035,-26.31606)"
-       x1="14.241117"
-       y1="26.996773"
-       x2="15.125"
-       y2="20.976084" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5254"
-       id="linearGradient5775"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99664,0,0,1.1932745,53.82035,-26.31606)"
-       x1="11.875"
-       y1="20.375"
-       x2="13.125"
-       y2="34.13559" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3503"
-       id="radialGradient5928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,97.72545,40.294064)"
-       spreadMethod="reflect"
-       cx="22.276291"
-       cy="21.520338"
-       fx="22.276291"
-       fy="21.520338"
-       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -775,18 +365,21 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="126.80533"
-     inkscape:cy="41.532441"
+     inkscape:cx="10.22266"
+     inkscape:cy="32.058291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="-12"
-     inkscape:window-y="0"
+     inkscape:window-width="3440"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -799,19 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
-       position="-14.142136,73.185552"
-       id="guide3490" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-21,-23.25"
-       id="guide5857" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="-49.5,-22.625"
-       id="guide5859" />
+       position="17.401268,34.125445"
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -829,12 +416,10 @@
             <rdf:li>device</rdf:li>
             <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>right</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-speaker-right-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -848,66 +433,43 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g8490"
-       transform="matrix(0.7071068,0.7071068,-0.7071068,0.7071068,-9.0528759,-47.851156)">
+       transform="matrix(-1.4142137,1.4142136,1.4142136,1.4142137,-196.55454,-335.21055)"
+       style="display:inline;stroke-width:0.5"
+       id="g8093"
+       inkscape:label="audio-volume-high">
       <path
-         sodipodi:nodetypes="ccccc"
-         id="path8492"
-         d="M 64.325669,10.506413 C 70.397099,7.0242733 77.468529,7.1135633 83.718529,10.506413 L 85.718529,14.899273 L 62.325669,14.899273 L 64.325669,10.506413 z"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path5491"
+         d="m 41.0002,202 h 2.484375 l 2.968754,-3 0.546871,0.0156 v 12 l -0.475297,8.3e-4 L 43.484575,208 H 41.0002 Z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none" />
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:0.5;marker:none"
+         id="rect6203"
+         width="16"
+         height="16"
+         x="41.000198"
+         y="197" />
       <path
-         sodipodi:nodetypes="csssccsssc"
-         d="M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 84.898489,14.148893 84.391069,13.829363 83.881339,13.563883 C 83.312379,13.267543 82.740559,13.038553 82.170169,12.891833 C 78.286959,11.872493 70.453649,11.829343 66.580509,12.845703 C 65.740619,13.064843 64.898909,13.457433 64.068479,13.977613 C 63.443239,14.369273 62.824389,14.833253 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8494" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 56.00019,205.0002 c 0,-2.81422 -1,-5.17173 -2.58557,-7 h -1.41443 v 1.48072 c 1.26466,1.51928 2,3.21936 2,5.51928 0,2.29992 -0.77953,4 -2,5.51928 v 1.48072 h 1.38128 c 1.46575,-1.64044 2.61872,-4.18578 2.61872,-7 z"
+         id="rect11714-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.827469,15.979023 L 65.014509,11.213023 C 70.275566,8.4697433 76.234822,7.8458533 82.953572,11.207463 L 84.922082,15.410963"
-         id="path8496"
-         sodipodi:nodetypes="cccc" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:0.50000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none"
+         d="m 53.00019,205.0002 c 0,-2.16664 -0.73878,-4.01982 -2,-5 h -1 v 2 c 0.60652,0.78878 1,1.75887 1,3 0,1.24113 -0.39348,2.21938 -1,3 v 2 h 1 c 1.2229,-0.99478 2,-2.8734 2,-5 z"
+         id="rect11703-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccscccs" />
       <path
-         sodipodi:nodetypes="cccc"
-         d="M 95.001579,28.523883 C 95.001579,28.523883 88.693549,15.595313 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593 C 60.028369,15.595313 55.03283,26.273883 55.03283,26.273883"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path8498" />
-      <path
-         transform="matrix(1.0469083,0,0,2.027027,51.01285,-35.409607)"
-         d="M 43.214285,32.24107 A 20.9375,4.9553571 0 1 1 1.3392849,32.24107 A 20.9375,4.9553571 0 1 1 43.214285,32.24107 z"
-         sodipodi:ry="4.9553571"
-         sodipodi:rx="20.9375"
-         sodipodi:cy="32.24107"
-         sodipodi:cx="22.276785"
-         id="path8500"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:0.68646109;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path8502"
-         d="M 95.16001,29.859216 C 95.34941,34.267437 86.35016,38.925273 74.250517,38.925273 C 62.150874,38.925273 53.120056,34.330572 53.341027,29.859216 C 53.151624,25.29316 62.150874,20.824727 74.250517,20.824727 C 86.35016,20.824727 95.19158,25.198457 95.16001,29.859216 z"
-         style="fill:url(#radialGradient8512);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 82.142459,27.943913 C 81.468389,30.131673 78.852759,31.329293 74.334599,31.329293 C 69.816449,31.329293 66.985899,29.952123 66.526739,27.943913 C 66.456009,26.238893 69.816449,24.570323 74.334599,24.570323 C 78.852759,24.570323 82.154249,26.203533 82.142459,27.943913 z"
-         id="path8504"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:0.96596354;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 67.476989,27.764793 C 68.447389,30.844053 71.145969,33.060833 74.320419,33.060843 C 77.514539,33.060843 80.226899,30.816463 81.181699,27.707393 C 80.281059,26.206763 76.900529,25.470543 74.291089,25.513813 C 70.986749,25.428073 68.434609,26.373493 67.476989,27.764793 z"
-         id="path8506"
-         sodipodi:nodetypes="csccc"
-         inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_Test.png"
-         inkscape:export-xdpi="67.489998"
-         inkscape:export-ydpi="67.489998" />
-      <path
-         id="path8508"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 62.722179,14.847493 C 62.595139,14.950093 62.343579,15.242643 62.217529,15.349973 C 60.346409,16.943173 58.58922,19.037813 57.10976,21.059983 C 54.51317,24.609093 52.7721,27.934983 52.7721,27.934983 M 95.897099,27.934983 C 95.897099,27.934983 91.349669,19.248213 86.035799,14.995723 C 85.825169,14.827163 85.613329,14.665563 85.400529,14.511753 C 85.300009,14.439103 84.752372,14.219223 84.651452,14.150133"
-         sodipodi:nodetypes="cssccsss" />
-      <path
-         id="path8510"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfd8f3;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 81.930899,13.855723 C 78.047689,12.836393 70.745629,12.793243 66.872489,13.809593"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:0.50000002;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+         mask="none"
+         clip-path="none"
+         d="m 50.00019,205.0002 c 0,-1.25733 -0.31165,-2.21571 -1,-3 h -1 v 3 0.375 2.625 h 1 c 0.67206,-0.8369 1,-1.74267 1,-3 z"
+         id="path6297-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zccccccz" />
     </g>
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-subwoofer-testing.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-subwoofer-testing.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,23 +14,146 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-subwoofer-testing.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-subwoofer-testing.png"
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <defs
      id="defs2645">
     <linearGradient
-       id="linearGradient6718">
+       id="linearGradient4389">
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="0"
+         id="stop4391" />
+      <stop
+         id="stop4393"
+         offset="1"
+         style="stop-color:#eeeeec;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4325">
+      <stop
+         id="stop4327"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1;" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="1"
+         id="stop4329" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient21608">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0"
+         id="stop21610" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="1"
+         id="stop21612" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15341">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0"
+         id="stop15343" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop15345" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6371">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0"
+         id="stop6373" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="1"
+         id="stop6375" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10872">
+      <stop
+         id="stop10874"
+         offset="0"
+         style="stop-color:#888a85;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e9e92;stop-opacity:1;"
+         offset="0.25301206"
+         id="stop10876" />
+      <stop
+         id="stop10878"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5254">
+      <stop
+         id="stop5256"
+         offset="0"
+         style="stop-color:#707469;stop-opacity:1;" />
+      <stop
+         id="stop5258"
+         offset="1"
+         style="stop-color:#2e3335;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10055">
+      <stop
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="0"
+         id="stop10057" />
+      <stop
+         id="stop10061"
+         offset="0.375"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="1"
+         id="stop10059" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4841">
+      <stop
+         id="stop4843"
+         offset="0"
+         style="stop-color:#babdb6;stop-opacity:1;" />
+      <stop
+         style="stop-color:#fcaf3e;stop-opacity:0.94117647;"
+         offset="0"
+         id="stop4845" />
+      <stop
+         id="stop4847"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1;" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4809">
       <stop
          style="stop-color:#babdb6;stop-opacity:1;"
          offset="0"
-         id="stop6720" />
+         id="stop4811" />
       <stop
-         id="stop6724"
+         id="stop4813"
+         offset="0"
+         style="stop-color:#ad7fa8;stop-opacity:1;" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1;"
+         offset="1"
+         id="stop4815" />
+      <stop
+         id="stop4817"
          offset="1"
          style="stop-color:#eeeeec;stop-opacity:1;" />
     </linearGradient>
@@ -53,26 +177,26 @@
          id="stop3349" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4389">
+       id="linearGradient3223">
       <stop
-         style="stop-color:#555753;stop-opacity:1;"
+         style="stop-color:#eeeeec;stop-opacity:1;"
          offset="0"
-         id="stop4391" />
+         id="stop3225" />
       <stop
-         id="stop4393"
+         style="stop-color:#babdb6;stop-opacity:1;"
          offset="1"
-         style="stop-color:#eeeeec;stop-opacity:1;" />
+         id="stop3227" />
     </linearGradient>
     <linearGradient
        id="linearGradient3503">
       <stop
-         id="stop3505"
+         style="stop-color:#babdb6;stop-opacity:1;"
          offset="0"
-         style="stop-color:#eeeeec;stop-opacity:1;" />
+         id="stop3239" />
       <stop
          id="stop3507"
          offset="1"
-         style="stop-color:#babdb6;stop-opacity:1;" />
+         style="stop-color:#eeeeec;stop-opacity:1;" />
     </linearGradient>
     <inkscape:perspective
        sodipodi:type="inkscape:persp3d"
@@ -83,15 +207,152 @@
        id="perspective2651" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient6984"
+       xlink:href="#linearGradient3503"
+       id="radialGradient3501"
+       cx="22.276291"
+       cy="32.248856"
+       fx="22.276291"
+       fy="32.248856"
+       r="20.319138"
+       gradientTransform="matrix(1,0,0,0.2366258,0,24.617945)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient3500"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7191227,0,0,0.7191227,23.696408,18.236608)"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578" />
+       gradientTransform="matrix(1,0,0,0.2366258,0,24.617945)"
+       cx="22.276291"
+       cy="32.248856"
+       fx="22.276291"
+       fy="32.248856"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient3232"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.474934,42.420392)"
+       cx="22.276291"
+       cy="21.520338"
+       fx="22.276291"
+       fy="21.520338"
+       r="20.319138"
+       spreadMethod="reflect" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient5689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0469084,0,0,0.4796469,270.37856,38.427671)"
+       cx="22.276291"
+       cy="32.248856"
+       fx="22.276291"
+       fy="32.248856"
+       r="20.319138" />
+    <inkscape:perspective
+       id="perspective3474"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4325"
+       id="radialGradient4359"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,-52.447261,-106.14795)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient5015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,42.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276291"
+       cy="21.520338"
+       fx="22.276291"
+       fy="21.520338"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient5062"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,98.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276291"
+       cy="21.520338"
+       fx="22.276291"
+       fy="21.520338"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4325"
+       id="radialGradient5064"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,98.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4389"
+       id="radialGradient5110"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,142.72007,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4389"
+       id="radialGradient3863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,92.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4389"
+       id="radialGradient3865"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,92.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4389"
+       id="radialGradient3906"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,92.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -103,19 +364,22 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="-48.821714"
-     inkscape:cy="66.867859"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="29.091148"
+     inkscape:cy="12.927483"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="0"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
      inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -128,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -148,13 +414,12 @@
           <rdf:Bag>
             <rdf:li>audio</rdf:li>
             <rdf:li>device</rdf:li>
-            <rdf:li>subwoofer</rdf:li>
+            <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
-            <rdf:li>testing</rdf:li>
-            <rdf:li>highlighted</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-subwoofer-testing</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -168,73 +433,37 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g6973"
-       transform="translate(-51.375,9.0155254e-8)">
+       style="display:inline;stroke-width:0.50000006"
+       id="g9428"
+       inkscape:label="display-projector"
+       transform="matrix(1.9999998,0,0,1.9999998,-194.0632,-913.99991)">
       <path
-         style="fill:#204a87;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 94.217316,39.045143 C 93.839661,41.471941 92.789441,43.219015 91.55403,43.219015 C 90.310955,43.219015 89.255378,41.450202 88.883794,38.999908 C 89.234301,37.817247 90.549918,37.23702 91.565441,37.271125 C 92.851403,37.203551 93.844629,37.948644 94.217316,39.045143 z"
-         id="path6730"
-         sodipodi:nodetypes="csccc" />
-      <path
-         sodipodi:nodetypes="csccc"
-         id="path6732"
-         d="M 62.393985,39.045143 C 62.016329,41.471941 60.96611,43.219015 59.730698,43.219015 C 58.487624,43.219015 57.432046,41.450202 57.060462,38.999908 C 57.410969,37.817247 58.726586,37.23702 59.742109,37.271125 C 61.028072,37.203551 62.021297,37.948644 62.393985,39.045143 z"
-         style="fill:#204a87;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:#204a87;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1.28661346;stroke-linecap:butt;stroke-linejoin:bevel;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 62.953967,6.9788731 C 73.409478,4.1293728 77.293929,4.3517447 87.917557,6.9788731 L 95.317117,13.152471 L 55.554408,13.152471 L 62.953967,6.9788731 z"
-         id="path6734"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 55.289577,13.137135 C 67.861736,9.7856746 82.504598,9.8716096 95.446529,13.137135 L 95.389975,39.76734 C 82.177445,42.114593 68.287824,42.159732 55.346132,39.902758 L 55.289577,13.137135 z"
-         id="path6736"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:type="arc"
-         style="fill:url(#radialGradient6984);fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:2.05839419;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path6738"
-         sodipodi:cx="84.365685"
-         sodipodi:cy="64.927307"
-         sodipodi:rx="21.396112"
-         sodipodi:ry="21.396112"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         transform="matrix(0,0.4858156,-0.4858156,0,100.43255,-14.78506)" />
-      <path
-         transform="matrix(0,0.2827849,-0.2827849,0,105.0933,2.3437637)"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         sodipodi:ry="21.396112"
-         sodipodi:rx="21.396112"
-         sodipodi:cy="64.927307"
-         sodipodi:cx="84.365685"
-         id="path6740"
-         style="fill:#bfd8f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.53625679;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:type="arc"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:5.06734753;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path6742"
-         sodipodi:cx="84.365685"
-         sodipodi:cy="64.927307"
-         sodipodi:rx="21.396112"
-         sodipodi:ry="21.396112"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         transform="matrix(0,0.1973419,-0.1973419,0,99.523923,9.5522206)" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path6744"
-         d="M 56.321159,13.950789 C 67.82398,10.961669 81.161179,10.935259 94.415609,13.950789 L 94.359059,38.893489 C 81.01047,40.978079 68.381909,41.160879 56.377709,39.028909 L 56.321159,13.950789 z"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#bfd8f3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(0,0.1973419,-0.1973419,0,81.702733,9.5522212)"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         sodipodi:ry="21.396112"
-         sodipodi:rx="21.396112"
-         sodipodi:cy="64.927307"
-         sodipodi:cx="84.365685"
-         id="path6746"
-         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:5.06734753;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
+         style="fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:0.75"
+         d="M 9.9960938,12 C 8.8902739,12 8,13.0462 8,14.3125 v 15.125 C 8,30.70378 8.8316801,32 9.9375,32 h 2 c 0,1.2663 0.948868,2 2.054688,2 h 1.992187 c 1.10582,0 1.953125,-0.7337 1.953125,-2 h 11.976562 c 0,1.2663 0.933243,2 2.039063,2 h 1.988281 c 1.10582,0 1.996094,-0.7337 1.996094,-2 h 2.003906 c 1.10584,0 1.996094,-1.29622 1.996094,-2.5625 V 14.3125 C 39.9375,13.0462 39.047246,12 37.941406,12 Z m 9.0488282,2 c 2.756,0 4.990234,2.23858 4.990234,5 0,2.76142 -2.234234,5 -4.990234,5 -2.756,0 -4.990234,-2.23858 -4.990234,-5 0,-2.76142 2.234234,-5 4.990234,-5 z m 11.970703,1.96875 c 1.665484,0 3.015625,1.350141 3.015625,3.015625 C 34.03125,20.649859 32.681109,22 31.015625,22 29.350141,22 28,20.649859 28,18.984375 28,17.318891 29.350141,15.96875 31.015625,15.96875 Z M 19,16 c -1.656854,0 -3,1.343146 -3,3 0,1.656854 1.343146,3 3,3 1.656854,0 3,-1.343146 3,-3 0,-1.656854 -1.343146,-3 -3,-3 z"
+         transform="matrix(0.50000005,0,0,0.50000005,97.03161,463)"
+         id="path9418"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssscssccsscssssssssssssssssssss" />
     </g>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:1.00000006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal"
+       d="m 25.000001,5 c 5.62844,4e-7 10.343459,2.0000007 13.999999,5.171141 v 2.82886 H 36.03856 C 33,10.470681 29.59984,9.0000003 25,9 c -4.59984,-3e-7 -8,1.55906 -11.03856,3.999999 H 11 v -2.76256 C 14.28088,7.3059393 19.37156,4.9999996 25.000001,5 Z"
+       id="rect11714-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;fill-rule:nonzero;stroke:none;stroke-width:1.00000006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal"
+       d="m 25,11 c 4.33328,0 8.03964,1.477561 10,4.000001 v 2 L 31,17 c -1.57756,-1.21304 -3.51774,-2 -6,-2 -2.48226,0 -4.43876,0.78696 -6,2 l -4,-1e-6 v -2 C 16.98956,12.5542 20.7468,11 25,11 Z"
+       id="rect11703-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#729fcf;fill-opacity:0.52697096;stroke:none;stroke-width:1.00000006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate;font-variant-east_asian:normal"
+       mask="none"
+       clip-path="none"
+       d="m 25,17 c 2.51466,0 4.43142,0.6233 6,2 l -1e-6,2 h -6 -0.75 H 19 v -2 c 1.6738,-1.34412 3.48534,-2 6,-2 z"
+       id="path6297-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zccccccz" />
   </g>
 </svg>

--- a/panels/sound/data/icons/scalable/devices/audio-subwoofer.svg
+++ b/panels/sound/data/icons/scalable/devices/audio-subwoofer.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,23 +14,146 @@
    height="48"
    id="svg2643"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    version="1.0"
    sodipodi:docname="audio-subwoofer.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/Users/eve/Documents/GNOME/SpeakerIcon_subwoofer.png"
-   inkscape:export-xdpi="67.489998"
-   inkscape:export-ydpi="67.489998">
+   inkscape:export-filename="/Users/eve/Documents/GNOME/audio-speaker.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <defs
      id="defs2645">
     <linearGradient
-       id="linearGradient6718">
+       id="linearGradient4389">
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="0"
+         id="stop4391" />
+      <stop
+         id="stop4393"
+         offset="1"
+         style="stop-color:#eeeeec;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4325">
+      <stop
+         id="stop4327"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1;" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="1"
+         id="stop4329" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient21608">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0"
+         id="stop21610" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="1"
+         id="stop21612" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15341">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0"
+         id="stop15343" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop15345" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6371">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0"
+         id="stop6373" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="1"
+         id="stop6375" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10872">
+      <stop
+         id="stop10874"
+         offset="0"
+         style="stop-color:#888a85;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e9e92;stop-opacity:1;"
+         offset="0.25301206"
+         id="stop10876" />
+      <stop
+         id="stop10878"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5254">
+      <stop
+         id="stop5256"
+         offset="0"
+         style="stop-color:#707469;stop-opacity:1;" />
+      <stop
+         id="stop5258"
+         offset="1"
+         style="stop-color:#2e3335;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10055">
+      <stop
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="0"
+         id="stop10057" />
+      <stop
+         id="stop10061"
+         offset="0.375"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="1"
+         id="stop10059" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4841">
+      <stop
+         id="stop4843"
+         offset="0"
+         style="stop-color:#babdb6;stop-opacity:1;" />
+      <stop
+         style="stop-color:#fcaf3e;stop-opacity:0.94117647;"
+         offset="0"
+         id="stop4845" />
+      <stop
+         id="stop4847"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1;" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4809">
       <stop
          style="stop-color:#babdb6;stop-opacity:1;"
          offset="0"
-         id="stop6720" />
+         id="stop4811" />
       <stop
-         id="stop6724"
+         id="stop4813"
+         offset="0"
+         style="stop-color:#ad7fa8;stop-opacity:1;" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1;"
+         offset="1"
+         id="stop4815" />
+      <stop
+         id="stop4817"
          offset="1"
          style="stop-color:#eeeeec;stop-opacity:1;" />
     </linearGradient>
@@ -53,38 +177,26 @@
          id="stop3349" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4389">
+       id="linearGradient3223">
       <stop
-         style="stop-color:#555753;stop-opacity:1;"
+         style="stop-color:#eeeeec;stop-opacity:1;"
          offset="0"
-         id="stop4391" />
+         id="stop3225" />
       <stop
-         id="stop4393"
+         style="stop-color:#babdb6;stop-opacity:1;"
          offset="1"
-         style="stop-color:#eeeeec;stop-opacity:1;" />
+         id="stop3227" />
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient5385"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,-9.0519739,70.961132)"
-       spreadMethod="pad"
-       cx="22.276297"
-       cy="21.099283"
-       fx="22.276297"
-       fy="21.099283"
-       r="20.319138" />
     <linearGradient
        id="linearGradient3503">
       <stop
-         id="stop3505"
+         style="stop-color:#babdb6;stop-opacity:1;"
          offset="0"
-         style="stop-color:#eeeeec;stop-opacity:1;" />
+         id="stop3239" />
       <stop
          id="stop3507"
          offset="1"
-         style="stop-color:#babdb6;stop-opacity:1;" />
+         style="stop-color:#eeeeec;stop-opacity:1;" />
     </linearGradient>
     <inkscape:perspective
        sodipodi:type="inkscape:persp3d"
@@ -95,44 +207,75 @@
        id="perspective2651" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient6516"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7191227,0,0,0.7191227,23.696408,18.236608)" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient6612"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7191227,0,0,0.7191227,23.696408,18.236608)"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4389"
-       id="radialGradient6645"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7191227,0,0,0.7191227,23.696408,18.236608)"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578" />
+       xlink:href="#linearGradient3503"
+       id="radialGradient3501"
+       cx="22.276291"
+       cy="32.248856"
+       fx="22.276291"
+       fy="32.248856"
+       r="20.319138"
+       gradientTransform="matrix(1,0,0,0.2366258,0,24.617945)"
+       gradientUnits="userSpaceOnUse" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3503"
-       id="radialGradient6705"
+       id="radialGradient3500"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7451713,-0.7451712,0.5114274,0.5114274,10.506623,78.557248)"
-       spreadMethod="reflect"
+       gradientTransform="matrix(1,0,0,0.2366258,0,24.617945)"
+       cx="22.276291"
+       cy="32.248856"
+       fx="22.276291"
+       fy="32.248856"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient3232"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,47.474934,42.420392)"
+       cx="22.276291"
+       cy="21.520338"
+       fx="22.276291"
+       fy="21.520338"
+       r="20.319138"
+       spreadMethod="reflect" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient5689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0469084,0,0,0.4796469,270.37856,38.427671)"
+       cx="22.276291"
+       cy="32.248856"
+       fx="22.276291"
+       fy="32.248856"
+       r="20.319138" />
+    <inkscape:perspective
+       id="perspective3474"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4325"
+       id="radialGradient4359"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,-52.447261,-106.14795)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="radialGradient5015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,42.720075,-107.89847)"
+       spreadMethod="pad"
        cx="22.276291"
        cy="21.520338"
        fx="22.276291"
@@ -140,48 +283,76 @@
        r="20.319138" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient6718"
-       id="radialGradient6716"
+       xlink:href="#linearGradient3503"
+       id="radialGradient5062"
        gradientUnits="userSpaceOnUse"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578"
-       gradientTransform="matrix(0.8545182,0,0,0.753115,12.273671,16.029579)" />
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,98.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276291"
+       cy="21.520338"
+       fx="22.276291"
+       fy="21.520338"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4325"
+       id="radialGradient5064"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,98.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4389"
-       id="radialGradient6728"
+       id="radialGradient5110"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7191227,0,0,0.7191227,23.696408,18.236608)"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578" />
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,142.72007,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4389"
-       id="radialGradient6748"
+       id="radialGradient3863"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7191227,0,0,0.7191227,23.696408,18.236608)"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578" />
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,92.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4389"
-       id="radialGradient6781"
+       id="radialGradient3865"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7191227,0,0,0.7191227,23.696408,18.236608)"
-       cx="84.365685"
-       cy="64.927307"
-       fx="84.365685"
-       fy="64.927307"
-       r="22.334578" />
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,92.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4389"
+       id="radialGradient3906"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0538312,-6.3027391e-8,1.2877417e-8,-0.7232676,92.720075,-107.89847)"
+       spreadMethod="pad"
+       cx="22.276297"
+       cy="21.099283"
+       fx="22.276297"
+       fy="21.099283"
+       r="20.319138" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -194,18 +365,21 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="-397.88007"
-     inkscape:cy="205.69941"
+     inkscape:cx="38.229248"
+     inkscape:cy="37.092309"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:snap-global="false"
-     inkscape:window-width="1680"
-     inkscape:window-height="1028"
-     inkscape:window-x="20"
-     inkscape:window-y="20"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="3440"
+     inkscape:window-y="0"
      showguides="false"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid2653"
@@ -218,11 +392,13 @@
     <sodipodi:guide
        orientation="1,0"
        position="23.969062,28.50558"
-       id="guide3488" />
+       id="guide3488"
+       inkscape:locked="false" />
     <sodipodi:guide
        orientation="0,1"
        position="17.401268,34.125445"
-       id="guide3490" />
+       id="guide3490"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata2648">
@@ -232,15 +408,18 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="" />
         <dc:subject>
           <rdf:Bag>
             <rdf:li>audio</rdf:li>
             <rdf:li>device</rdf:li>
-            <rdf:li>subwoofer</rdf:li>
+            <rdf:li>speaker</rdf:li>
             <rdf:li>output</rdf:li>
+            <rdf:li>center</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>audio-subwoofer</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Evangeline McGlynn</dc:title>
@@ -254,72 +433,37 @@
      inkscape:groupmode="layer"
      id="layer1">
     <g
-       id="g6770">
+       style="display:inline;stroke-width:0.50000006"
+       id="g9428"
+       inkscape:label="display-projector"
+       transform="matrix(1.9999998,0,0,1.9999998,-194.0632,-913.99991)">
       <path
-         sodipodi:nodetypes="csccc"
-         id="path3286"
-         d="M 42.842316,39.045143 C 42.464661,41.471941 41.414441,43.219015 40.17903,43.219015 C 38.935955,43.219015 37.880378,41.450202 37.508794,38.999908 C 37.859301,37.817247 39.174918,37.23702 40.190441,37.271125 C 41.476403,37.203551 42.469629,37.948644 42.842316,39.045143 z"
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 11.018985,39.045143 C 10.641329,41.471941 9.5911095,43.219015 8.3556983,43.219015 C 7.1126243,43.219015 6.0570463,41.450202 5.6854623,38.999908 C 6.0359693,37.817247 7.3515863,37.23702 8.3671093,37.271125 C 9.6530715,37.203551 10.646297,37.948644 11.018985,39.045143 z"
-         id="path3288"
-         sodipodi:nodetypes="csccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path3264"
-         d="M 11.578967,6.9788731 C 22.034478,4.1293728 25.918929,4.3517447 36.542557,6.9788731 L 43.942117,13.152471 L 4.1794077,13.152471 L 11.578967,6.9788731 z"
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1.28661346;stroke-linecap:butt;stroke-linejoin:bevel;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path3266"
-         d="M 3.9145768,13.137135 C 16.486736,9.7856746 31.129598,9.8716096 44.071529,13.137135 L 44.014975,39.76734 C 30.802445,42.114593 16.912824,42.159732 3.9711319,39.902758 L 3.9145768,13.137135 z"
-         style="fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(0,0.4858156,-0.4858156,0,49.057554,-14.78506)"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         sodipodi:ry="21.396112"
-         sodipodi:rx="21.396112"
-         sodipodi:cy="64.927307"
-         sodipodi:cx="84.365685"
-         id="path3238"
-         style="fill:url(#radialGradient6781);fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:2.05839419;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:type="arc"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.53625679;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path3260"
-         sodipodi:cx="84.365685"
-         sodipodi:cy="64.927307"
-         sodipodi:rx="21.396112"
-         sodipodi:ry="21.396112"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         transform="matrix(0,0.2827849,-0.2827849,0,53.7183,2.3437637)" />
-      <path
-         transform="matrix(0,0.1973419,-0.1973419,0,48.148923,9.5522206)"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         sodipodi:ry="21.396112"
-         sodipodi:rx="21.396112"
-         sodipodi:cy="64.927307"
-         sodipodi:cx="84.365685"
-         id="path6518"
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:5.06734753;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         sodipodi:type="arc" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 4.9461591,13.950789 C 16.44898,10.961669 29.786179,10.935259 43.040609,13.950789 L 42.984059,38.893489 C 29.63547,40.978079 17.006909,41.160879 5.0027091,39.028909 L 4.9461591,13.950789 z"
-         id="path6561"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:type="arc"
-         style="fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:5.06734753;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path6581"
-         sodipodi:cx="84.365685"
-         sodipodi:cy="64.927307"
-         sodipodi:rx="21.396112"
-         sodipodi:ry="21.396112"
-         d="M 105.7618,64.927307 A 21.396112,21.396112 0 1 1 62.969572,64.927307 A 21.396112,21.396112 0 1 1 105.7618,64.927307 z"
-         transform="matrix(0,0.1973419,-0.1973419,0,30.327733,9.5522212)" />
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+         d="M 9.9960938,12 C 8.8902739,12 8,13.0462 8,14.3125 v 15.125 C 8,30.70378 8.8316801,32 9.9375,32 h 2 c 0,1.2663 0.948868,2 2.054688,2 h 1.992187 c 1.10582,0 1.953125,-0.7337 1.953125,-2 h 11.976562 c 0,1.2663 0.933243,2 2.039063,2 h 1.988281 c 1.10582,0 1.996094,-0.7337 1.996094,-2 h 2.003906 c 1.10584,0 1.996094,-1.29622 1.996094,-2.5625 V 14.3125 C 39.9375,13.0462 39.047246,12 37.941406,12 Z m 9.0488282,2 c 2.756,0 4.990234,2.23858 4.990234,5 0,2.76142 -2.234234,5 -4.990234,5 -2.756,0 -4.990234,-2.23858 -4.990234,-5 0,-2.76142 2.234234,-5 4.990234,-5 z m 11.970703,1.96875 c 1.665484,0 3.015625,1.350141 3.015625,3.015625 C 34.03125,20.649859 32.681109,22 31.015625,22 29.350141,22 28,20.649859 28,18.984375 28,17.318891 29.350141,15.96875 31.015625,15.96875 Z M 19,16 c -1.656854,0 -3,1.343146 -3,3 0,1.656854 1.343146,3 3,3 1.656854,0 3,-1.343146 3,-3 0,-1.656854 -1.343146,-3 -3,-3 z"
+         transform="matrix(0.50000005,0,0,0.50000005,97.03161,463)"
+         id="path9418"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssscssccsscssssssssssssssssssss" />
     </g>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:2.32782054;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 25.000001,5 c 5.62844,4e-7 10.343459,2.0000007 13.999999,5.171141 v 2.82886 H 36.03856 C 33,10.470681 29.59984,9.0000003 25,9 c -4.59984,-3e-7 -8,1.55906 -11.03856,3.999999 H 11 v -2.76256 C 14.28088,7.3059393 19.37156,4.9999996 25.000001,5 Z"
+       id="rect11714-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none;stroke-width:2.32782054;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 25,11 c 4.33328,0 8.03964,1.477561 10,4.000001 v 2 L 31,17 c -1.57756,-1.21304 -3.51774,-2 -6,-2 -2.48226,0 -4.43876,0.78696 -6,2 l -4,-1e-6 v -2 C 16.98956,12.5542 20.7468,11 25,11 Z"
+       id="rect11703-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scccscccs" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.23529412;stroke:none;stroke-width:2.32782054;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       mask="none"
+       clip-path="none"
+       d="m 25,17 c 2.51466,0 4.43142,0.6233 6,2 l -1e-6,2 h -6 -0.75 H 19 v -2 c 1.6738,-1.34412 3.48534,-2 6,-2 z"
+       id="path6297-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zccccccz" />
   </g>
 </svg>


### PR DESCRIPTION
Apply patch for bgo 775170 that adds the missing icon for mono speakers, and re-style all speaker icons.

https://phabricator.endlessm.com/T19634