### PR TITLE
debian: Use autogen.sh instead of dh_auto_configure

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,7 @@ override_dh_autoreconf:
 	dh_autoreconf --as-needed
 
 override_dh_auto_configure:
+	NOCONFIGURE=1 ./autogen.sh
 	dh_auto_configure -- \
 		--libexecdir=\$${prefix}/lib/gnome-control-center \
 		--with-gnome-session-libexecdir=\$${prefix}/lib/gnome-session \


### PR DESCRIPTION
dh_auto_configure defaults to running configure, which means we can’t
easily build the package from git.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T19532