### PR TITLE
Revert "debian: Use autogen.sh instead of dh_auto_configure"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,6 @@ override_dh_autoreconf:
 	dh_autoreconf --as-needed
 
 override_dh_auto_configure:
-	NOCONFIGURE=1 ./autogen.sh
 	dh_auto_configure -- \
 		--libexecdir=\$${prefix}/lib/gnome-control-center \
 		--with-gnome-session-libexecdir=\$${prefix}/lib/gnome-session \


### PR DESCRIPTION
This reverts commit 50fd5284b998e6642828af28dfbf7c4b4bed0942.

The upstream tarball does not contain an autogen.sh script, so the
package build fails when building from a tarball rather than from git.
Since we build from tarballs, this is embarrassing.

https://phabricator.endlessm.com/T19532