### PR TITLE
info: use UDisks to retrieve disk size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,7 +143,8 @@ PKG_CHECK_MODULES(DISPLAY_PANEL, $COMMON_MODULES gnome-desktop-3.0 >= 3.1.0
                   colord >= $COLORD_REQUIRED_VERSION
                   upower-glib >= 0.99.0)
 PKG_CHECK_MODULES(INFO_PANEL, $COMMON_MODULES libgtop-2.0
-		  polkit-gobject-1 >= $POLKIT_REQUIRED_VERSION)
+		  polkit-gobject-1 >= $POLKIT_REQUIRED_VERSION
+		  udisks2 >= 2.1.8)
 PKG_CHECK_MODULES(KEYBOARD_PANEL, $COMMON_MODULES
                   gnome-desktop-3.0 >= $GNOME_DESKTOP_REQUIRED_VERSION
                   x11)


### PR DESCRIPTION
The current code relies on GLib API and uses the
available mounts to calculate the available partition
size. This is because this code assumes that more
than one OS can be installed in the same drive, and
wouldn't make sense to show the whole disk size in
this situation.

However, Endless OS is not meant to be installed with
other OSes on different partitions, and for our partners
it might be bad to show a disk space smaller than what
they put on their hardware.

Fix that by using the UDisks API to get the real size
of the full disks.

https://phabricator.endlessm.com/T19907