### PR TITLE
info: Check if drive is both removable and media-removable

### DIFF
--- a/panels/info/cc-info-panel.c
+++ b/panels/info/cc-info-panel.c
@@ -508,9 +508,10 @@ get_primary_disc_info (CcInfoPanel *self)
 
       /* Skip removable devices */
       if (!drive ||
-          udisks_drive_get_removable (drive) ||
-          udisks_drive_get_ejectable (drive) ||
-          g_hash_table_contains (added_drives, udisks_drive_get_id (drive)))
+          g_hash_table_contains (added_drives, udisks_drive_get_id (drive)) ||
+          (udisks_drive_get_ejectable (drive) &&
+           udisks_drive_get_removable (drive) &&
+           udisks_drive_get_media_removable (drive)))
         {
           continue;
         }


### PR DESCRIPTION
Checking if a given drive is removable is not enough, because eMMC
drives are legitimately removable, and also because the DBus 'Removable'
property is essentially a guess and should not be used alone.

This commit, then, only considers drives that are ejectable, removable
and media-removable simultaneously when deciding which drives to skip.

https://phabricator.endlessm.com/T20504