### PR TITLE
connection-editor: Expose metered connection switch

### DIFF
--- a/panels/network/connection-editor/ce-page-details.c
+++ b/panels/network/connection-editor/ce-page-details.c
@@ -132,6 +132,53 @@ all_user_changed (GtkToggleButton *b, CEPageDetails *page)
 }
 
 static void
+restrict_data_changed (GtkSwitch *sw, GParamSpec *pspec, CEPageDetails *page)
+{
+        NMSettingConnection *s_con;
+        NMMetered metered;
+
+        s_con = nm_connection_get_setting_connection (CE_PAGE (page)->connection);
+
+        if (gtk_switch_get_active (sw))
+                metered = NM_METERED_YES;
+        else
+                metered = NM_METERED_NO;
+
+        g_object_set (s_con, "metered", metered, NULL);
+}
+
+static void
+update_restrict_data (CEPageDetails *page)
+{
+        NMSettingConnection *s_con;
+        NMMetered metered;
+        GtkWidget *widget;
+        const gchar *type;
+
+        s_con = nm_connection_get_setting_connection (CE_PAGE (page)->connection);
+
+        if (s_con == NULL)
+                return;
+
+        /* Disable for VPN; NetworkManager does not implement that yet (see
+         * bug https://bugzilla.gnome.org/show_bug.cgi?id=792618) */
+        type = nm_setting_connection_get_connection_type (s_con);
+        if (g_str_equal (type, NM_SETTING_VPN_SETTING_NAME))
+                return;
+
+        metered = nm_setting_connection_get_metered (s_con);
+
+        widget = GTK_WIDGET (gtk_builder_get_object (CE_PAGE (page)->builder, "restrict_data_grid"));
+        gtk_widget_show (widget);
+
+        widget = GTK_WIDGET (gtk_builder_get_object (CE_PAGE (page)->builder, "restrict_data_switch"));
+        gtk_switch_set_active (GTK_SWITCH (widget), metered == NM_METERED_YES || metered == NM_METERED_GUESS_YES);
+
+        g_signal_connect (widget, "notify::active", G_CALLBACK (restrict_data_changed), page);
+        g_signal_connect_swapped (widget, "notify::active", G_CALLBACK (ce_page_changed), page);
+}
+
+static void
 connect_details_page (CEPageDetails *page)
 {
         NMSettingConnection *sc;
@@ -238,6 +285,9 @@ connect_details_page (CEPageDetails *page)
         g_signal_connect (widget, "toggled",
                           G_CALLBACK (all_user_changed), page);
         g_signal_connect_swapped (widget, "toggled", G_CALLBACK (ce_page_changed), page);
+
+        /* Restrict Data switch */
+        update_restrict_data (page);
 
         /* Forget button */
         widget = GTK_WIDGET (gtk_builder_get_object (CE_PAGE (page)->builder, "button_forget"));

--- a/panels/network/connection-editor/details-page.ui
+++ b/panels/network/connection-editor/details-page.ui
@@ -355,6 +355,65 @@
         <property name="height">1</property>
       </packing>
     </child>
+
+    <!-- "Restrict Data Usage" section -->
+    <child>
+      <object class="GtkGrid" id="restrict_data_grid">
+        <property name="can_focus">True</property>
+        <property name="column_spacing">18</property>
+        <property name="margin_bottom">12</property>
+
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="xalign">0</property>
+            <property name="label" translatable="yes">Restrict Data Usage</property>
+            <property name="hexpand">True</property>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkSwitch" id="restrict_data_switch">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="xalign">0</property>
+            <property name="label" translatable="yes">Prevents background network activity in order to limit costs and prevent caps from exceed on metered connections.</property>
+            <property name="wrap">True</property>
+            <property name="max_width_chars">60</property>
+            <style>
+              <class name="dim-label" />
+            </style>
+            <attributes>
+              <attribute name="scale" value="0.8" />
+            </attributes>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">11</property>
+        <property name="width">2</property>
+        <property name="height">1</property>
+      </packing>
+    </child>
+
     <child>
       <object class="GtkButton" id="button_forget">
         <property name="visible">True</property>
@@ -370,7 +429,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">11</property>
+        <property name="top_attach">12</property>
         <property name="width">2</property>
         <property name="height">1</property>
       </packing>


### PR DESCRIPTION
NetworkManager supports marking a connection as metered, meaning
that connection is e.g. charged by its usage or extremely limited.
When a network is metered, background network usage must cease
and the behavior of the various OS pieces must be adjusted.

This patch adds a switch to set a connection as metered or not.
The property is imediately propagated to NetworkManager.

https://phabricator.endlessm.com/T20771