### PR TITLE
network: Turn metered data switch into a check button

### DIFF
--- a/panels/network/connection-editor/ce-page-details.c
+++ b/panels/network/connection-editor/ce-page-details.c
@@ -132,14 +132,14 @@ all_user_changed (GtkToggleButton *b, CEPageDetails *page)
 }
 
 static void
-restrict_data_changed (GtkSwitch *sw, GParamSpec *pspec, CEPageDetails *page)
+restrict_data_changed (GtkToggleButton *toggle, GParamSpec *pspec, CEPageDetails *page)
 {
         NMSettingConnection *s_con;
         NMMetered metered;
 
         s_con = nm_connection_get_setting_connection (CE_PAGE (page)->connection);
 
-        if (gtk_switch_get_active (sw))
+        if (gtk_toggle_button_get_active (toggle))
                 metered = NM_METERED_YES;
         else
                 metered = NM_METERED_NO;
@@ -168,11 +168,10 @@ update_restrict_data (CEPageDetails *page)
 
         metered = nm_setting_connection_get_metered (s_con);
 
-        widget = GTK_WIDGET (gtk_builder_get_object (CE_PAGE (page)->builder, "restrict_data_grid"));
+        widget = GTK_WIDGET (gtk_builder_get_object (CE_PAGE (page)->builder, "restrict_data_check"));
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (widget),
+                                      metered == NM_METERED_YES || metered == NM_METERED_GUESS_YES);
         gtk_widget_show (widget);
-
-        widget = GTK_WIDGET (gtk_builder_get_object (CE_PAGE (page)->builder, "restrict_data_switch"));
-        gtk_switch_set_active (GTK_SWITCH (widget), metered == NM_METERED_YES || metered == NM_METERED_GUESS_YES);
 
         g_signal_connect (widget, "notify::active", G_CALLBACK (restrict_data_changed), page);
         g_signal_connect_swapped (widget, "notify::active", G_CALLBACK (ce_page_changed), page);
@@ -286,7 +285,7 @@ connect_details_page (CEPageDetails *page)
                           G_CALLBACK (all_user_changed), page);
         g_signal_connect_swapped (widget, "toggled", G_CALLBACK (ce_page_changed), page);
 
-        /* Restrict Data switch */
+        /* Restrict Data check */
         update_restrict_data (page);
 
         /* Forget button */

--- a/panels/network/connection-editor/details-page.ui
+++ b/panels/network/connection-editor/details-page.ui
@@ -358,51 +358,43 @@
 
     <!-- "Restrict Data Usage" section -->
     <child>
-      <object class="GtkGrid" id="restrict_data_grid">
+      <object class="GtkCheckButton" id="restrict_data_check">
         <property name="can_focus">True</property>
-        <property name="column_spacing">18</property>
         <property name="margin_bottom">12</property>
 
         <child>
-          <object class="GtkLabel">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="xalign">0</property>
-            <property name="label" translatable="yes">Restrict Data Usage</property>
-            <property name="hexpand">True</property>
-          </object>
-        </child>
+            <property name="orientation">vertical</property>
 
-        <child>
-          <object class="GtkSwitch" id="restrict_data_switch">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-          <packing>
-            <property name="left_attach">1</property>
-            <property name="top_attach">0</property>
-          </packing>
-        </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Restrict background data usage</property>
+                <property name="hexpand">True</property>
+              </object>
+            </child>
 
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="xalign">0</property>
-            <property name="label" translatable="yes">Prevents background network activity in order to limit costs and prevent caps from exceed on metered connections.</property>
-            <property name="wrap">True</property>
-            <property name="max_width_chars">60</property>
-            <style>
-              <class name="dim-label" />
-            </style>
-            <attributes>
-              <attribute name="scale" value="0.8" />
-            </attributes>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Appropriate for connections that have data charges or limits.</property>
+                <property name="wrap">True</property>
+                <property name="max_width_chars">60</property>
+                <style>
+                  <class name="dim-label" />
+                </style>
+                <attributes>
+                  <attribute name="scale" value="0.8" />
+                </attributes>
+              </object>
+            </child>
           </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-          </packing>
         </child>
 
       </object>


### PR DESCRIPTION
Per guidance of the design team, since the dialog has not
enough room for switches.

https://phabricator.endlessm.com/T20771