### PR TITLE
power: Add 20 and 25 minutes suspend timeouts

### DIFF
--- a/panels/power/power.ui
+++ b/panels/power/power.ui
@@ -14,6 +14,14 @@
         <col id="1">900</col>
       </row>
       <row>
+        <col id="0" translatable="yes">20 minutes</col>
+        <col id="1">1200</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">25 minutes</col>
+        <col id="1">1500</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">30 minutes</col>
         <col id="1">1800</col>
       </row>


### PR DESCRIPTION
Pad out the 15-30 minutes mark with 5 minute increments. This also means
that the new 20-minute default for suspending is now in the list, and
will be selected when the panel is opened, rather than the 30 minutes
option.

See https://bugzilla.gnome.org/show_bug.cgi?id=681869

https://phabricator.endlessm.com/T20634