### PR TITLE
updates: Introduce Automatic Updates panel

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,7 @@ COLORD_REQUIRED_VERSION=0.1.34
 COLORD_GTK_REQUIRED_VERSION=0.1.24
 PWQUALITY_REQUIRED_VERSION=1.2.2
 GRILO_REQUIRED_VERSION=0.3.0
+MOGWAI_REQUIRED_VERSION=0.1.0
 
 COMMON_MODULES="gtk+-3.0 >= $GTK_REQUIRED_VERSION
  glib-2.0 >= $GLIB_REQUIRED_VERSION
@@ -350,6 +351,19 @@ else
 fi
 AM_CONDITIONAL(BUILD_WACOM, [test x${have_wacom} = xyes])
 
+# Automatic updates
+PKG_CHECK_MODULES(UPDATES_PANEL, $COMMON_MODULES
+                  libnm >= 1.8
+                  libnma >= 1.8
+                  mogwai-tariff-0 >= $MOGWAI_REQUIRED_VERSION)
+
+if test "x$have_networkmanager" = xno ; then
+        linux_error_or_warn "*** Automatic Updates panel will not be built (NetworkManager not found) ***"
+else
+	AC_DEFINE(BUILD_UPDATES, 1, [Define to 1 to build the Network panel])
+fi
+AM_CONDITIONAL(BUILD_UPDATES, [test x$have_networkmanager = xyes])
+
 # Kerberos kerberos support
 AC_PATH_PROG(KRB5_CONFIG, krb5-config, no)
 if test "$KRB5_CONFIG" = "no"; then
@@ -565,6 +579,8 @@ panels/notifications/Makefile
 panels/notifications/gnome-notifications-panel.desktop.in
 panels/universal-access/Makefile
 panels/universal-access/gnome-universal-access-panel.desktop.in
+panels/updates/Makefile
+panels/updates/gnome-updates-panel.desktop.in
 panels/user-accounts/Makefile
 panels/user-accounts/data/Makefile
 panels/user-accounts/data/gnome-user-accounts-panel.desktop.in

--- a/panels/Makefile.am
+++ b/panels/Makefile.am
@@ -19,6 +19,10 @@ SUBDIRS= \
 	sharing \
 	printers
 
+if BUILD_UPDATES
+SUBDIRS += updates
+endif
+
 if BUILD_WACOM
 SUBDIRS += wacom
 endif

--- a/panels/updates/Makefile.am
+++ b/panels/updates/Makefile.am
@@ -1,0 +1,42 @@
+# This is used in PANEL_CFLAGS
+cappletname = updates
+
+AM_CPPFLAGS = 						\
+	$(PANEL_CFLAGS)					\
+	$(UPDATES_PANEL_CFLAGS)				\
+	-DGNOMELOCALEDIR="\"$(datadir)/locale\""	\
+	$(NULL)
+
+BUILT_SOURCES =			\
+	cc-updates-resources.c	\
+	cc-updates-resources.h
+
+noinst_LTLIBRARIES = libupdates.la
+
+nodist_libupdates_la_SOURCES =	\
+	$(BUILT_SOURCES)
+
+libupdates_la_SOURCES =	\
+	cc-tariff-editor.c		\
+	cc-tariff-editor.h		\
+	cc-updates-panel.c		\
+	cc-updates-panel.h
+
+libupdates_la_LIBADD = $(PANEL_LIBS) $(UPDATES_PANEL_LIBS)
+
+resource_files = $(shell glib-compile-resources --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/updates.gresource.xml)
+cc-updates-resources.c: updates.gresource.xml $(resource_files)
+	$(AM_V_GEN) glib-compile-resources --target=$@ --sourcedir=$(srcdir) --generate-source --c-name cc_updates $<
+cc-updates-resources.h: updates.gresource.xml $(resource_files)
+	$(AM_V_GEN) glib-compile-resources --target=$@ --sourcedir=$(srcdir) --generate-header --c-name cc_updates $<
+
+@INTLTOOL_DESKTOP_RULE@
+
+desktopdir = $(datadir)/applications
+desktop_in_files = gnome-updates-panel.desktop.in
+desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
+
+CLEANFILES = $(desktop_in_files) $(desktop_DATA) $(BUILT_SOURCES)
+EXTRA_DIST = $(resource_files) updates.gresource.xml
+
+-include $(top_srcdir)/git.mk

--- a/panels/updates/cc-tariff-editor.c
+++ b/panels/updates/cc-tariff-editor.c
@@ -1,0 +1,487 @@
+/* cc-tariff-editor.c
+ *
+ * Copyright © 2018 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cc-tariff-editor.h"
+
+#include <gdesktop-enums.h>
+#include <libmogwai-tariff/tariff-builder.h>
+
+#define CLOCK_SCHEMA     "org.gnome.desktop.interface"
+#define CLOCK_FORMAT_KEY "clock-format"
+#define SECONDS_PER_DAY  (24 * 60 * 60)
+
+struct _CcTariffEditor
+{
+  GtkGrid             parent;
+
+  GtkAdjustment      *adjustment_from_hours;
+  GtkAdjustment      *adjustment_from_minutes;
+  GtkAdjustment      *adjustment_to_hours;
+  GtkAdjustment      *adjustment_to_minutes;
+
+  GtkWidget          *stack_from;
+  GtkWidget          *stack_to;
+
+  GBytes             *tariff_as_bytes;
+
+  /* Clock format */
+  GSettings          *settings_clock;
+  GDesktopClockFormat clock_format;
+
+  guint8              time_period_from;
+  guint8              time_period_to;
+
+  guint64             seconds_to_start;
+  guint64             seconds_to_end;
+};
+
+G_DEFINE_TYPE (CcTariffEditor, cc_tariff_editor, GTK_TYPE_GRID)
+
+G_DEFINE_QUARK (CcTariffEditorError, cc_tariff_editor_error)
+
+enum
+{
+  TARIFF_CHANGED,
+  LAST_SIGNAL
+};
+
+enum
+{
+  AM,
+  PM,
+};
+
+
+static void on_time_changed_cb (CcTariffEditor *self);
+
+
+static guint signals[LAST_SIGNAL] = { 0, };
+
+
+/*
+ * Auxiliary methods
+ */
+
+static void
+update_seconds_from_adjustments (CcTariffEditor *self)
+{
+  guint factor_from = 0;
+  guint factor_to = 0;
+
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_12H)
+    {
+      factor_from = self->time_period_from == AM ? 0 : SECONDS_PER_DAY / 2;
+      factor_to = self->time_period_to == AM ? 0 : SECONDS_PER_DAY / 2;
+    }
+
+  self->seconds_to_start = gtk_adjustment_get_value (self->adjustment_from_hours) * 60 * 60 + factor_from +
+                           gtk_adjustment_get_value (self->adjustment_from_minutes) * 60;
+
+  self->seconds_to_end = gtk_adjustment_get_value (self->adjustment_to_hours) * 60 * 60 + factor_to +
+                         gtk_adjustment_get_value (self->adjustment_to_minutes) * 60;
+
+  /*
+   * If 'from' > 'to', e.g. [22:15, 05:45), this period is crossing days and we
+   * need to add +1 day to the end date. Otherwise, e.g, [13:10, 19:15), the period
+   * is contained in a single day, and we don't need to do anything.
+   */
+  if (self->seconds_to_start >= self->seconds_to_end)
+    self->seconds_to_end += SECONDS_PER_DAY;
+}
+
+static gboolean
+setup_tariff (CcTariffEditor  *self,
+              MwtTariff       *tariff,
+              GError         **error)
+{
+  g_autoptr(GDateTime) maximum_date = NULL;
+  GDateTime *period_start, *period_end;
+  MwtPeriod *base_period, *period;
+  GPtrArray *periods;
+
+  if (!tariff)
+    return FALSE;
+
+  /*
+   * Right now, it only parsed the same kind of tariff it generates, a tariff
+   * with these 2 periods:
+   *
+   *  1 → forbidden downloads period
+   *  2 → allowed downloads period
+   *
+   * Anything that does not comform to that is ignored.
+   */
+
+  periods = mwt_tariff_get_periods (tariff);
+
+  if (periods->len != 2)
+    {
+      g_set_error (error,
+                   CC_TARIFF_EDITOR_ERROR,
+                   CC_TARIFF_EDITOR_ERROR_NOT_SUPPORTED,
+                   "Cannot parse complex tariffs yet");
+      return FALSE;
+    }
+
+  /* Validate and setup the forbidden downloads period */
+  maximum_date = g_date_time_new_utc (9999, 12, 31, 23 , 59, 59);
+  base_period = g_ptr_array_index (periods, 0);
+  period = g_ptr_array_index (periods, 1);
+
+  if (mwt_period_get_repeat_type (base_period) != MWT_PERIOD_REPEAT_NONE ||
+      g_date_time_to_unix (mwt_period_get_start (base_period)) != 0 ||
+      g_date_time_to_unix (mwt_period_get_end (base_period)) != g_date_time_to_unix (maximum_date))
+    {
+      g_set_error (error,
+                   CC_TARIFF_EDITOR_ERROR,
+                   CC_TARIFF_EDITOR_ERROR_WRONG_FORMAT,
+                   "Base tariff is wrong");
+      return FALSE;
+    }
+
+  if (mwt_period_get_repeat_type (period) != MWT_PERIOD_REPEAT_DAY ||
+      mwt_period_get_repeat_period (period) != 1)
+    {
+      g_set_error (error,
+                   CC_TARIFF_EDITOR_ERROR,
+                   CC_TARIFF_EDITOR_ERROR_WRONG_FORMAT,
+                   "Repeating period is wrong");
+      return FALSE;
+    }
+
+  g_signal_handlers_block_by_func (self->adjustment_from_hours, on_time_changed_cb, self);
+  g_signal_handlers_block_by_func (self->adjustment_from_minutes, on_time_changed_cb, self);
+  g_signal_handlers_block_by_func (self->adjustment_to_hours, on_time_changed_cb, self);
+  g_signal_handlers_block_by_func (self->adjustment_to_minutes, on_time_changed_cb, self);
+
+  period_start = mwt_period_get_start (period);
+  period_end = mwt_period_get_end (period);
+
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_24H)
+    {
+      gtk_adjustment_set_value (self->adjustment_from_hours, g_date_time_get_hour (period_start));
+      gtk_adjustment_set_value (self->adjustment_from_minutes, g_date_time_get_minute (period_start));
+      gtk_adjustment_set_value (self->adjustment_to_hours, g_date_time_get_hour (period_end));
+      gtk_adjustment_set_value (self->adjustment_to_minutes, g_date_time_get_minute (period_end));
+    }
+  else
+    {
+      self->time_period_from = g_date_time_get_hour (period_start) < 12 ? AM : PM;
+      self->time_period_to = g_date_time_get_hour (period_end) < 12 ? AM : PM;
+
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_from), self->time_period_from == AM ? "am" : "pm");
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_to), self->time_period_to == AM ? "am" : "pm");
+
+      /* Special-case: 12 AM/PM must show up as 12, not as 0 AM/PM */
+      if (g_date_time_get_hour (period_start) % 12 == 0)
+        gtk_adjustment_set_value (self->adjustment_from_hours, 12);
+      else
+        gtk_adjustment_set_value (self->adjustment_from_hours, g_date_time_get_hour (period_start) % 12);
+
+      if (g_date_time_get_hour (period_end) % 12 == 0)
+        gtk_adjustment_set_value (self->adjustment_to_hours, 12);
+      else
+        gtk_adjustment_set_value (self->adjustment_to_hours, g_date_time_get_hour (period_end) % 12);
+
+      gtk_adjustment_set_value (self->adjustment_from_minutes, g_date_time_get_minute (period_start));
+      gtk_adjustment_set_value (self->adjustment_to_minutes, g_date_time_get_minute (period_end));
+    }
+
+  g_signal_handlers_unblock_by_func (self->adjustment_from_hours, on_time_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->adjustment_from_minutes, on_time_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->adjustment_to_hours, on_time_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->adjustment_to_minutes, on_time_changed_cb, self);
+
+  return TRUE;
+}
+
+static void
+update_tariff (CcTariffEditor *self,
+               gboolean        should_notify)
+{
+  g_autoptr(MwtTariffBuilder) tariff_builder = NULL;
+  g_autoptr(MwtPeriod) forbidden_period = NULL;
+  g_autoptr(GDateTime) forbidden_start = NULL;
+  g_autoptr(GDateTime) forbidden_end = NULL;
+  g_autoptr(MwtPeriod) allowed_period = NULL;
+  g_autoptr(GDateTime) allowed_start = NULL;
+  g_autoptr(GDateTime) allowed_end = NULL;
+
+  /*
+   *  This is the a very simple implementation of a tariff, with 2 defined
+   * periods:
+   *
+   *  1. Forbidden: [0, forever), downloads are forbidden.
+   *  2. Allowed: [start hour, end hour) daily, downloads are allowed.
+   */
+
+  tariff_builder = mwt_tariff_builder_new ();
+  mwt_tariff_builder_set_name (tariff_builder, "System Tariff");
+
+  update_seconds_from_adjustments (self);
+
+  /* 1. Forbidden downloads period */
+  forbidden_start = g_date_time_new_from_unix_utc (0);
+  forbidden_end = g_date_time_new_utc (9999, 12, 31, 23 , 59, 59);
+  forbidden_period = mwt_period_new (forbidden_start,
+                                     forbidden_end,
+                                     MWT_PERIOD_REPEAT_NONE, 0,
+                                     "capacity-limit", 0,
+                                     NULL);
+
+  mwt_tariff_builder_add_period (tariff_builder, forbidden_period);
+
+  /* 2. Allowed downloads period */
+  allowed_start = g_date_time_new_from_unix_utc (self->seconds_to_start);
+  allowed_end = g_date_time_new_from_unix_utc (self->seconds_to_end);
+  allowed_period = mwt_period_new (allowed_start,
+                                   allowed_end,
+                                   MWT_PERIOD_REPEAT_DAY, 1,
+                                   "capacity-limit", G_MAXUINT64,
+                                   NULL);
+
+  mwt_tariff_builder_add_period (tariff_builder, allowed_period);
+
+  /* Store the new tariff */
+  g_clear_pointer (&self->tariff_as_bytes, g_bytes_unref);
+  self->tariff_as_bytes = mwt_tariff_builder_get_tariff_as_bytes (tariff_builder);
+
+  if (!self->tariff_as_bytes)
+    g_critical ("Error building tariff file");
+  else if (should_notify)
+    g_signal_emit (self, signals[TARIFF_CHANGED], 0);
+}
+
+static void
+update_adjustments (CcTariffEditor *self)
+{
+  g_debug ("Updating adjustments");
+
+  /* From */
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_24H)
+    {
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_from), "blank");
+
+      gtk_adjustment_set_lower (self->adjustment_from_hours, 0);
+      gtk_adjustment_set_upper (self->adjustment_from_hours, 23);
+    }
+  else
+    {
+      self->time_period_from = gtk_adjustment_get_value (self->adjustment_from_hours) < 12 ? AM : PM;
+
+      if (self->time_period_from == AM)
+        gtk_stack_set_visible_child_name (GTK_STACK (self->stack_from), "am");
+      else
+        gtk_stack_set_visible_child_name (GTK_STACK (self->stack_from), "pm");
+
+      gtk_adjustment_set_lower (self->adjustment_from_hours, 1);
+      gtk_adjustment_set_upper (self->adjustment_from_hours, 12);
+    }
+
+  /* To */
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_24H)
+    {
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_to), "blank");
+
+      gtk_adjustment_set_lower (self->adjustment_to_hours, 0);
+      gtk_adjustment_set_upper (self->adjustment_to_hours, 23);
+    }
+  else
+    {
+      self->time_period_to = gtk_adjustment_get_value (self->adjustment_to_hours) < 12 ? AM : PM;
+
+      if (self->time_period_to == AM)
+        gtk_stack_set_visible_child_name (GTK_STACK (self->stack_to), "am");
+      else
+        gtk_stack_set_visible_child_name (GTK_STACK (self->stack_to), "pm");
+
+      gtk_adjustment_set_lower (self->adjustment_to_hours, 1);
+      gtk_adjustment_set_upper (self->adjustment_to_hours, 12);
+    }
+}
+
+
+/*
+ * Callbacks
+ */
+
+static void
+on_clock_settings_changed_cb (GSettings      *settings_display,
+                              gchar          *key,
+                              CcTariffEditor *self)
+{
+  self->clock_format = g_settings_get_enum (settings_display, CLOCK_FORMAT_KEY);
+
+  update_adjustments (self);
+}
+
+static gboolean
+on_hours_output_cb (GtkSpinButton  *spin,
+                    CcTariffEditor *self)
+{
+  GtkAdjustment *adjustment;
+  g_autofree gchar *text = NULL;
+
+  adjustment = gtk_spin_button_get_adjustment (spin);
+
+  if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_12H)
+    text = g_strdup_printf ("%.0f", gtk_adjustment_get_value (adjustment));
+  else
+    text = g_strdup_printf ("%02.0f", gtk_adjustment_get_value (adjustment));
+
+  gtk_entry_set_text (GTK_ENTRY (spin), text);
+
+  return TRUE;
+}
+
+static gboolean
+on_minutes_output_cb (GtkSpinButton  *spin,
+                      CcTariffEditor *self)
+{
+  GtkAdjustment *adjustment;
+  g_autofree gchar *text = NULL;
+
+  adjustment = gtk_spin_button_get_adjustment (spin);
+
+  text = g_strdup_printf ("%02.0f", gtk_adjustment_get_value (adjustment));
+  gtk_entry_set_text (GTK_ENTRY (spin), text);
+
+  return TRUE;
+}
+
+static void
+on_time_changed_cb (CcTariffEditor *self)
+{
+  update_tariff (self, TRUE);
+}
+
+static void
+on_time_period_from_clicked_cb (GtkButton      *button,
+                                CcTariffEditor *self)
+{
+  if (self->time_period_from == AM)
+    {
+      self->time_period_from = PM;
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_from), "pm");
+    }
+  else
+    {
+      self->time_period_from = AM;
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_from), "am");
+    }
+}
+
+static void
+on_time_period_to_clicked_cb (GtkButton      *button,
+                              CcTariffEditor *self)
+{
+  if (self->time_period_to == AM)
+    {
+      self->time_period_to = PM;
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_to), "pm");
+    }
+  else
+    {
+      self->time_period_to = AM;
+      gtk_stack_set_visible_child_name (GTK_STACK (self->stack_to), "am");
+    }
+}
+
+
+/*
+ * GObject overrides
+ */
+
+static void
+cc_tariff_editor_finalize (GObject *object)
+{
+  CcTariffEditor *self = (CcTariffEditor *)object;
+
+  g_clear_object (&self->settings_clock);
+  g_clear_pointer (&self->tariff_as_bytes, g_bytes_unref);
+
+  G_OBJECT_CLASS (cc_tariff_editor_parent_class)->finalize (object);
+}
+
+
+static void
+cc_tariff_editor_class_init (CcTariffEditorClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->finalize = cc_tariff_editor_finalize;
+
+  signals[TARIFF_CHANGED] = g_signal_new ("tariff-changed",
+                                          CC_TYPE_TARIFF_EDITOR,
+                                          G_SIGNAL_RUN_FIRST,
+                                          0, NULL, NULL, NULL,
+                                          G_TYPE_NONE,
+                                          0);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/updates/cc-tariff-editor.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_from_hours);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_from_minutes);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_to_hours);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, adjustment_to_minutes);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, stack_from);
+  gtk_widget_class_bind_template_child (widget_class, CcTariffEditor, stack_to);
+
+  gtk_widget_class_bind_template_callback (widget_class, on_hours_output_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_minutes_output_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_time_changed_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_time_period_from_clicked_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_time_period_to_clicked_cb);
+}
+
+static void
+cc_tariff_editor_init (CcTariffEditor *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+
+  /* Clock settings */
+  self->settings_clock = g_settings_new (CLOCK_SCHEMA);
+  self->clock_format = g_settings_get_enum (self->settings_clock, CLOCK_FORMAT_KEY);
+
+  update_adjustments (self);
+
+  g_signal_connect (self->settings_clock,
+                    "changed::"CLOCK_FORMAT_KEY,
+                    G_CALLBACK (on_clock_settings_changed_cb),
+                    self);
+}
+
+GBytes*
+cc_tariff_editor_get_tariff_as_bytes (CcTariffEditor *self)
+{
+  g_return_val_if_fail (CC_IS_TARIFF_EDITOR (self), NULL);
+
+  return self->tariff_as_bytes;
+}
+
+void
+cc_tariff_editor_load_tariff (CcTariffEditor  *self,
+                              MwtTariff       *tariff,
+                              GError         **error)
+{
+  g_return_if_fail (CC_IS_TARIFF_EDITOR (self));
+
+  if (setup_tariff (self, tariff, error))
+    update_tariff (self, FALSE);
+}

--- a/panels/updates/cc-tariff-editor.h
+++ b/panels/updates/cc-tariff-editor.h
@@ -1,0 +1,46 @@
+/* cc-tariff-editor.c
+ *
+ * Copyright © 2018 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <libmogwai-tariff/tariff.h>
+
+G_BEGIN_DECLS
+
+typedef enum
+{
+  CC_TARIFF_EDITOR_ERROR_NOT_SUPPORTED,
+  CC_TARIFF_EDITOR_ERROR_WRONG_FORMAT,
+} CcTariffEditorError;
+
+#define CC_TARIFF_EDITOR_ERROR (cc_tariff_editor_error_quark ())
+#define CC_TYPE_TARIFF_EDITOR  (cc_tariff_editor_get_type())
+
+G_DECLARE_FINAL_TYPE (CcTariffEditor, cc_tariff_editor, CC, TARIFF_EDITOR, GtkGrid)
+
+GQuark     cc_tariff_editor_error_quark         (void);
+
+GBytes*    cc_tariff_editor_get_tariff_as_bytes (CcTariffEditor  *self);
+
+void       cc_tariff_editor_load_tariff         (CcTariffEditor  *self,
+                                                 MwtTariff       *tariff,
+                                                 GError         **error);
+
+G_END_DECLS

--- a/panels/updates/cc-tariff-editor.h
+++ b/panels/updates/cc-tariff-editor.h
@@ -35,12 +35,12 @@ typedef enum
 
 G_DECLARE_FINAL_TYPE (CcTariffEditor, cc_tariff_editor, CC, TARIFF_EDITOR, GtkGrid)
 
-GQuark     cc_tariff_editor_error_quark         (void);
+GQuark    cc_tariff_editor_error_quark           (void);
 
-GBytes*    cc_tariff_editor_get_tariff_as_bytes (CcTariffEditor  *self);
+GVariant* cc_tariff_editor_get_tariff_as_variant (CcTariffEditor  *self);
 
-void       cc_tariff_editor_load_tariff         (CcTariffEditor  *self,
-                                                 MwtTariff       *tariff,
-                                                 GError         **error);
+void      cc_tariff_editor_load_tariff           (CcTariffEditor  *self,
+                                                  MwtTariff       *tariff,
+                                                  GError         **error);
 
 G_END_DECLS

--- a/panels/updates/cc-tariff-editor.ui
+++ b/panels/updates/cc-tariff-editor.ui
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="CcTariffEditor" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="column-spacing">12</property>
+
+    <!-- Start time -->
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="yalign">0.0</property>
+        <property name="label" translatable="yes">From</property>
+        <style>
+          <class name="dim-label" />
+        </style>
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">0</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkSpinButton">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="orientation">vertical</property>
+        <property name="adjustment">adjustment_from_hours</property>
+        <signal name="output" handler="on_hours_output_cb" object="CcTariffEditor" swapped="no" />
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">1</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkSpinButton">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="orientation">vertical</property>
+        <property name="adjustment">adjustment_from_minutes</property>
+        <signal name="output" handler="on_minutes_output_cb" object="CcTariffEditor" swapped="no" />
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">2</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkStack" id="stack_from">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkButton">
+            <property name="label" translatable="yes" comments="This is the short form for the time period in the morning">AM</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <signal name="clicked" handler="on_time_period_from_clicked_cb" object="CcTariffEditor" swapped="no" />
+            <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+          </object>
+          <packing>
+            <property name="name">am</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="label" translatable="yes" comments="This is the short form for the time period in the afternoon">PM</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <signal name="clicked" handler="on_time_period_from_clicked_cb" object="CcTariffEditor" swapped="no" />
+            <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+          </object>
+          <packing>
+            <property name="name">pm</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="name">blank</property>
+          </packing>
+        </child>
+
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">3</property>
+      </packing>
+    </child>
+
+    <!-- End time -->
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="yalign">0.0</property>
+        <property name="label" translatable="yes">To</property>
+        <style>
+          <class name="dim-label" />
+        </style>
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">4</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkSpinButton">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="orientation">vertical</property>
+        <property name="adjustment">adjustment_to_hours</property>
+        <signal name="output" handler="on_hours_output_cb" object="CcTariffEditor" swapped="no" />
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">5</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkSpinButton">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="orientation">vertical</property>
+        <property name="adjustment">adjustment_to_minutes</property>
+        <signal name="output" handler="on_minutes_output_cb" object="CcTariffEditor" swapped="no" />
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">6</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkStack" id="stack_to">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkButton">
+            <property name="label" translatable="yes" comments="This is the short form for the time period in the morning">AM</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <signal name="clicked" handler="on_time_period_to_clicked_cb" object="CcTariffEditor" swapped="no" />
+            <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+          </object>
+          <packing>
+            <property name="name">am</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="label" translatable="yes" comments="This is the short form for the time period in the afternoon">PM</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <signal name="clicked" handler="on_time_period_to_clicked_cb" object="CcTariffEditor" swapped="no" />
+            <signal name="clicked" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+          </object>
+          <packing>
+            <property name="name">pm</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="name">blank</property>
+          </packing>
+        </child>
+
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">7</property>
+      </packing>
+    </child>
+
+  </template>
+
+  <!-- Adjustments for the spinners -->
+  <object class="GtkAdjustment" id="adjustment_from_hours">
+    <property name="upper">23</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+  <object class="GtkAdjustment" id="adjustment_from_minutes">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+  <object class="GtkAdjustment" id="adjustment_to_hours">
+    <property name="upper">23</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+  <object class="GtkAdjustment" id="adjustment_to_minutes">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
+  </object>
+</interface>

--- a/panels/updates/cc-tariff-editor.ui
+++ b/panels/updates/cc-tariff-editor.ui
@@ -198,6 +198,7 @@
 
   <!-- Adjustments for the spinners -->
   <object class="GtkAdjustment" id="adjustment_from_hours">
+    <property name="value">22</property>
     <property name="upper">23</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
@@ -210,6 +211,7 @@
     <signal name="notify::value" handler="on_time_changed_cb" object="CcTariffEditor" swapped="yes" />
   </object>
   <object class="GtkAdjustment" id="adjustment_to_hours">
+    <property name="value">6</property>
     <property name="upper">23</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>

--- a/panels/updates/cc-updates-panel.c
+++ b/panels/updates/cc-updates-panel.c
@@ -1,0 +1,684 @@
+/* cc-updates-panel.c
+ *
+ * Copyright © 2018 Endless, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Georges Basile Stavracas Neto <georges@endlessm.com>
+ */
+
+#include "cc-tariff-editor.h"
+#include "cc-updates-panel.h"
+#include "cc-updates-resources.h"
+
+#include <glib/gi18n.h>
+#include <libmogwai-tariff/tariff-loader.h>
+#include <NetworkManager.h>
+
+#define NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED "connection.allow-downloads-when-metered"
+#define SYSTEM_TARIFF_FILENAME                  "system-tariff"
+
+struct _CcUpdatesPanel
+{
+  CcPanel             parent;
+
+  GtkWidget          *automatic_updates_container;
+  GtkWidget          *automatic_updates_switch;
+  GtkWidget          *metered_data_label;
+  GtkWidget          *network_name_label;
+  GtkWidget          *network_settings_label;
+  GtkWidget          *network_status_icon;
+  GtkWidget          *scheduled_updates_switch;
+  CcTariffEditor     *tariff_editor;
+
+  /* Network Manager */
+  NMClient           *nm_client;
+  NMDevice           *current_device;
+
+  /* Signal handlers */
+  guint               changed_id;
+  guint               save_tariff_timeout_id;
+
+  GCancellable       *cancellable;
+};
+
+
+static void          on_automatic_updates_switch_changed_cb      (GtkSwitch      *sw,
+                                                                  GParamSpec     *pspec,
+                                                                  CcUpdatesPanel *self);
+
+static void          on_network_changed_cb                       (CcUpdatesPanel *self);
+
+static void          on_network_changes_commited_cb              (GObject        *source,
+                                                                  GAsyncResult   *result,
+                                                                  gpointer        user_data);
+
+static void          on_scheduled_updates_switch_changed_cb      (GtkSwitch      *sw,
+                                                                  GParamSpec     *pspec,
+                                                                  CcUpdatesPanel *self);
+
+static void          on_tariff_changed_cb                        (CcTariffEditor *tariff_editor,
+                                                                  CcUpdatesPanel *self);
+
+static void          on_tariff_file_deleted_cb                   (GFile          *file,
+                                                                  GAsyncResult   *result,
+                                                                  CcUpdatesPanel *self);
+
+
+G_DEFINE_TYPE (CcUpdatesPanel, cc_updates_panel, CC_TYPE_PANEL)
+
+enum
+{
+  PROP_PARAMETERS = 1,
+  N_PROPS
+};
+
+
+/*
+ * Auxiliary methods
+ */
+
+static void
+set_automatic_updates_setting (NMConnection   *connection,
+                               gboolean        enabled)
+{
+  NMSettingUser *setting_user;
+  g_autoptr(GError) error = NULL;
+
+  g_debug ("Setting "NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED" to %d", enabled);
+
+  setting_user = NM_SETTING_USER (nm_connection_get_setting (connection, NM_TYPE_SETTING_USER));
+
+  nm_setting_user_set_data (setting_user,
+                            NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED,
+                            enabled ? "1" : "0",
+                            &error);
+
+  if (error)
+    {
+      g_warning ("Error storing "NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED": %s", error->message);
+      return;
+    }
+
+  nm_remote_connection_commit_changes_async (NM_REMOTE_CONNECTION (connection),
+                                             TRUE, /* save to disk */
+                                             NULL,
+                                             on_network_changes_commited_cb,
+                                             NULL);
+}
+
+static void
+get_active_connection_and_device (CcUpdatesPanel  *self,
+                                  NMDevice       **out_device,
+                                  NMConnection   **out_connection,
+                                  NMAccessPoint  **out_ap)
+{
+  NMActiveConnection *active_connection = NULL;
+  NMConnection *connection = NULL;
+  const GPtrArray *active_devices = NULL;
+  NMAccessPoint *ap = NULL;
+  NMDevice *active_device = NULL;
+
+  active_connection = nm_client_get_primary_connection (self->nm_client);
+
+  /* If no primary connection is already present, try and use the connecting one */
+  if (!active_connection)
+    active_connection = nm_client_get_activating_connection (self->nm_client);
+
+  if (active_connection)
+    {
+      connection = NM_CONNECTION (nm_active_connection_get_connection (active_connection));
+      active_devices = nm_active_connection_get_devices (active_connection);
+
+      if (active_devices && active_devices->len > 0)
+        {
+          /* This array is guaranteed to have only one element */
+          active_device = g_ptr_array_index (active_devices, 0);
+
+          if (NM_IS_DEVICE_WIFI (active_device))
+            ap = nm_device_wifi_get_active_access_point (NM_DEVICE_WIFI (active_device));
+        }
+    }
+
+  if (out_device)
+    *out_device = active_device;
+
+  if (out_connection)
+    *out_connection = connection;
+
+  if (out_ap)
+    *out_ap = ap;
+}
+
+static void
+ensure_setting_user (CcUpdatesPanel *self,
+                     NMConnection   *connection)
+{
+  NMSettingUser *setting_user;
+
+  if (!connection)
+    return;
+
+  setting_user = NM_SETTING_USER (nm_connection_get_setting (connection, NM_TYPE_SETTING_USER));
+
+  if (!setting_user)
+    {
+      g_autoptr(GError) error = NULL;
+      NMSettingConnection *setting;
+      NMMetered metered;
+      gboolean enabled;
+
+      g_debug ("Creating a new custom config file for the current connection…");
+
+      /* Add a new NMSettingUser to this connection */
+      setting_user = NM_SETTING_USER (nm_setting_user_new ());
+      nm_connection_add_setting (connection, NM_SETTING (setting_user));
+
+      /* The default value depends on the metered state of the connection */
+      setting = nm_connection_get_setting_connection (connection);
+      metered = nm_setting_connection_get_metered (setting);
+      enabled = metered != NM_METERED_YES && metered != NM_METERED_GUESS_YES;
+
+      set_automatic_updates_setting (connection, enabled);
+
+      g_signal_handlers_block_by_func (self->automatic_updates_switch,
+                                       on_automatic_updates_switch_changed_cb,
+                                       self);
+
+      gtk_switch_set_active (GTK_SWITCH (self->automatic_updates_switch), enabled);
+
+      g_signal_handlers_unblock_by_func (self->automatic_updates_switch,
+                                         on_automatic_updates_switch_changed_cb,
+                                         self);
+
+      if (error)
+        g_warning ("Error creating custom config for connection: %s", error->message);
+    }
+}
+
+static const gchar *
+get_wifi_icon_from_strength (NMAccessPoint *ap)
+{
+  guint8 strength;
+
+  if (!ap)
+    return "network-wireless-signal-none-symbolic";
+
+  strength = nm_access_point_get_strength (ap);
+
+  if (strength < 20)
+    return "network-wireless-signal-none-symbolic";
+  else if (strength < 40)
+    return "network-wireless-signal-weak-symbolic";
+  else if (strength < 50)
+    return "network-wireless-signal-ok-symbolic";
+  else if (strength < 80)
+    return "network-wireless-signal-good-symbolic";
+  else
+    return "network-wireless-signal-excellent-symbolic";
+}
+
+static const gchar *
+get_network_status_icon_name (CcUpdatesPanel *self,
+                              NMDevice       *device,
+                              NMAccessPoint  *ap)
+{
+  if (NM_IS_DEVICE_WIFI (device))
+    {
+      switch (nm_client_get_state (self->nm_client))
+        {
+        case NM_STATE_UNKNOWN:
+        case NM_STATE_ASLEEP:
+        case NM_STATE_DISCONNECTING:
+          return "network-wireless-offline-symbolic";
+
+        case NM_STATE_DISCONNECTED:
+          return "network-wireless-offline-symbolic";
+
+        case NM_STATE_CONNECTING:
+          return "network-wireless-acquiring-symbolic";
+
+        case NM_STATE_CONNECTED_LOCAL:
+        case NM_STATE_CONNECTED_SITE:
+          return "network-wireless-no-route-symbolic";
+
+        case NM_STATE_CONNECTED_GLOBAL:
+          return get_wifi_icon_from_strength (ap);
+        }
+    }
+  else
+    {
+      switch (nm_client_get_state (self->nm_client))
+        {
+        case NM_STATE_UNKNOWN:
+        case NM_STATE_ASLEEP:
+        case NM_STATE_DISCONNECTING:
+          return "network-wired-disconnected-symbolic";
+
+        case NM_STATE_DISCONNECTED:
+          return "network-wired-offline-symbolic";
+
+        case NM_STATE_CONNECTING:
+          return "network-wired-acquiring-symbolic";
+
+        case NM_STATE_CONNECTED_LOCAL:
+        case NM_STATE_CONNECTED_SITE:
+          return "network-wired-no-route-symbolic";
+
+        case NM_STATE_CONNECTED_GLOBAL:
+          return "network-wired-symbolic";
+        }
+    }
+
+  return "network-wireless-offline-symbolic";
+}
+
+static void
+update_active_network (CcUpdatesPanel *self)
+{
+  NMAccessPoint *ap;
+  NMConnection *connection;
+  NMDevice *device;
+  const gchar *icon_name;
+
+  get_active_connection_and_device (self, &device, &connection, &ap);
+
+  /* Setup the new device */
+  if (g_set_object (&self->current_device, device) && device)
+    {
+      /* Cleanup previous device handler */
+      if (self->changed_id > 0)
+        {
+          g_source_remove (self->changed_id);
+          self->changed_id = 0;
+        }
+
+      self->changed_id = g_signal_connect_swapped (device,
+                                                   "state-changed",
+                                                   G_CALLBACK (on_network_changed_cb),
+                                                   self);
+    }
+
+  /* Icon */
+  icon_name = get_network_status_icon_name (self, device, ap);
+  gtk_image_set_from_icon_name (GTK_IMAGE (self->network_status_icon), icon_name, 4);
+
+  /* Name */
+  if (ap)
+    {
+      GBytes *ssid = nm_access_point_get_ssid (ap);
+      g_autofree gchar *title = nm_utils_ssid_to_utf8 (g_bytes_get_data (ssid, NULL), g_bytes_get_size (ssid));
+
+      gtk_label_set_label (GTK_LABEL (self->network_name_label), title);
+    }
+  else
+    {
+      if (connection)
+        gtk_label_set_label (GTK_LABEL (self->network_name_label), _("Connected"));
+      else
+        gtk_label_set_label (GTK_LABEL (self->network_name_label), _("No active connection"));
+    }
+
+  /* Metered status */
+  gtk_widget_set_visible (self->metered_data_label, connection != NULL);
+
+  if (connection)
+    {
+      NMSettingConnection *setting;
+      NMMetered metered;
+
+      setting = nm_connection_get_setting_connection (connection);
+      metered = nm_setting_connection_get_metered (setting);
+
+      if (metered == NM_METERED_YES || metered == NM_METERED_GUESS_YES)
+        gtk_label_set_label (GTK_LABEL (self->metered_data_label), _("Limited data plan connection"));
+      else
+        gtk_label_set_label (GTK_LABEL (self->metered_data_label), _("Unlimited data plan connection"));
+    }
+
+  /* Automatic Updates switch */
+  gtk_widget_set_sensitive (self->automatic_updates_container, connection != NULL);
+
+  ensure_setting_user (self, connection);
+
+  if (connection)
+    {
+      NMSettingUser *setting_user;
+      const gchar *value;
+
+      setting_user = NM_SETTING_USER (nm_connection_get_setting (connection, NM_TYPE_SETTING_USER));
+      value = nm_setting_user_get_data (setting_user, NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED);
+
+      g_signal_handlers_block_by_func (self->automatic_updates_switch,
+                                       on_automatic_updates_switch_changed_cb,
+                                       self);
+
+      gtk_switch_set_active (GTK_SWITCH (self->automatic_updates_switch), g_strcmp0 (value, "1") == 0);
+
+      g_signal_handlers_unblock_by_func (self->automatic_updates_switch,
+                                         on_automatic_updates_switch_changed_cb,
+                                         self);
+    }
+}
+
+static void
+load_tariff (CcUpdatesPanel *self)
+{
+  g_autoptr(MwtTariffLoader) tariff_loader = NULL;
+  g_autoptr(GBytes) bytes = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *tariff_path = NULL;
+  gchar *contents = NULL;
+  gsize size = 0;
+
+  g_debug ("Loading tariff");
+
+  tariff_path = g_build_filename (g_get_user_config_dir (), SYSTEM_TARIFF_FILENAME, NULL);
+  g_file_get_contents (tariff_path, &contents, &size, &error);
+  if (error)
+    {
+      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        g_warning ("Error reading tariff file: %s", error->message);
+      return;
+    }
+
+  bytes = g_bytes_new_take (contents, size);
+  tariff_loader = mwt_tariff_loader_new ();
+  mwt_tariff_loader_load_from_bytes (tariff_loader, bytes, &error);
+  if (error)
+    {
+      g_warning ("Error loading tariff: %s", error->message);
+      return;
+    }
+
+  g_signal_handlers_block_by_func (self->tariff_editor, on_tariff_changed_cb, self);
+  g_signal_handlers_block_by_func (self->scheduled_updates_switch, on_scheduled_updates_switch_changed_cb, self);
+
+  cc_tariff_editor_load_tariff (self->tariff_editor,
+                                mwt_tariff_loader_get_tariff (tariff_loader),
+                                &error);
+
+  if (error)
+    g_warning ("Error loading tariff: %s", error->message);
+  else
+    gtk_switch_set_active (GTK_SWITCH (self->scheduled_updates_switch), TRUE);
+
+  g_signal_handlers_unblock_by_func (self->scheduled_updates_switch, on_scheduled_updates_switch_changed_cb, self);
+  g_signal_handlers_unblock_by_func (self->tariff_editor, on_tariff_changed_cb, self);
+}
+
+static void
+save_tariff (CcUpdatesPanel *self)
+{
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *tariff_path = NULL;
+  GBytes *tariff_bytes;
+
+  tariff_path = g_build_filename (g_get_user_config_dir (), SYSTEM_TARIFF_FILENAME, NULL);
+  tariff_bytes = cc_tariff_editor_get_tariff_as_bytes (self->tariff_editor);
+
+  if (!tariff_bytes || !gtk_switch_get_active (GTK_SWITCH (self->scheduled_updates_switch)))
+    {
+      g_autoptr(GFile) file = g_file_new_for_path (tariff_path);
+
+      g_debug ("Deleting tariff");
+
+      g_file_delete_async (file,
+                           G_PRIORITY_LOW,
+                           NULL,
+                           (GAsyncReadyCallback) on_tariff_file_deleted_cb,
+                           &error);
+      return;
+    }
+
+  g_debug ("Saving tariff");
+
+  g_file_set_contents (tariff_path,
+                       g_bytes_get_data (tariff_bytes, NULL),
+                       g_bytes_get_size (tariff_bytes),
+                       &error);
+
+  if (error)
+    g_critical ("Error saving tariff file: %s", error->message);
+}
+
+static gboolean
+save_tariff_cb (gpointer user_data)
+{
+  CcUpdatesPanel *self = CC_UPDATES_PANEL (user_data);
+
+  save_tariff (self);
+  self->save_tariff_timeout_id = 0;
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+schedule_save_tariff (CcUpdatesPanel *self)
+{
+  g_debug ("Scheduling save tariff");
+
+  if (self->save_tariff_timeout_id > 0)
+    g_source_remove (self->save_tariff_timeout_id);
+
+  self->save_tariff_timeout_id = g_timeout_add_seconds (2, save_tariff_cb, self);
+}
+
+
+/*
+ * Callbacks
+ */
+
+static void
+on_automatic_updates_switch_changed_cb (GtkSwitch      *sw,
+                                        GParamSpec     *pspec,
+                                        CcUpdatesPanel *self)
+{
+  NMConnection *connection;
+  gboolean active;
+
+  active = gtk_switch_get_active (sw);
+  get_active_connection_and_device (self, NULL, &connection, NULL);
+
+  set_automatic_updates_setting (connection, active);
+
+  /* Disable scheduled updates if automatic updates are disabled too */
+  if (!active)
+    gtk_switch_set_active (GTK_SWITCH (self->scheduled_updates_switch), FALSE);
+}
+
+static gboolean
+on_change_network_link_activated_cb (GtkLabel       *label,
+                                     gchar          *uri,
+                                     CcUpdatesPanel *self)
+{
+  g_autoptr(GError) error = NULL;
+  NMDevice *device;
+  CcShell *shell;
+
+  shell = cc_panel_get_shell (CC_PANEL (self));
+
+  get_active_connection_and_device (self, &device, NULL, NULL);
+
+  if (!device || !NM_IS_DEVICE_WIFI (device))
+    cc_shell_set_active_panel_from_id (shell, "network", NULL, &error);
+  else
+    cc_shell_set_active_panel_from_id (shell, "wifi", NULL, &error);
+
+  if (error)
+    {
+      g_warning ("Error activating panel: %s", error->message);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+on_network_changed_cb (CcUpdatesPanel *self)
+{
+  g_debug ("NetworkManager changed state");
+
+  update_active_network (self);
+}
+
+static void
+on_network_changes_commited_cb (GObject      *source,
+                                GAsyncResult *result,
+                                gpointer      user_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  nm_remote_connection_commit_changes_finish (NM_REMOTE_CONNECTION (source), result, &error);
+
+  if (error)
+    g_warning ("Error storing "NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED": %s", error->message);
+}
+
+static void
+on_scheduled_updates_switch_changed_cb (GtkSwitch      *sw,
+                                        GParamSpec     *pspec,
+                                        CcUpdatesPanel *self)
+{
+  g_debug ("Scheduled Updates changed state");
+
+  schedule_save_tariff (self);
+}
+
+static void
+on_tariff_changed_cb (CcTariffEditor *tariff_editor,
+                      CcUpdatesPanel *self)
+{
+  g_debug ("The saved tariff changed");
+
+  schedule_save_tariff (self);
+}
+
+static void
+on_tariff_file_deleted_cb (GFile          *file,
+                           GAsyncResult   *result,
+                           CcUpdatesPanel *self)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_file_delete_finish (file, result, &error);
+
+  if (error && !g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+    g_critical ("Error deleting tariff file: %s", error->message);
+}
+
+
+/*
+ * GObject overrides
+ */
+
+static void
+cc_updates_panel_dispose (GObject *object)
+{
+  CcUpdatesPanel *self = (CcUpdatesPanel *)object;
+
+  if (self->save_tariff_timeout_id > 0)
+    {
+      save_tariff (self);
+      g_source_remove (self->save_tariff_timeout_id);
+      self->save_tariff_timeout_id = 0;
+    }
+
+  G_OBJECT_CLASS (cc_updates_panel_parent_class)->dispose (object);
+}
+
+static void
+cc_updates_panel_finalize (GObject *object)
+{
+  CcUpdatesPanel *self = (CcUpdatesPanel *)object;
+
+  g_cancellable_cancel (self->cancellable);
+  g_clear_object (&self->cancellable);
+  g_clear_object (&self->current_device);
+  g_clear_object (&self->nm_client);
+
+  G_OBJECT_CLASS (cc_updates_panel_parent_class)->finalize (object);
+}
+
+static void
+cc_updates_panel_set_property (GObject      *object,
+                               guint         prop_id,
+                               const GValue *value,
+                               GParamSpec   *pspec)
+{
+  switch (prop_id)
+    {
+    case PROP_PARAMETERS:
+      /* Nothing to do */
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+cc_updates_panel_class_init (CcUpdatesPanelClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->dispose = cc_updates_panel_dispose;
+  object_class->finalize = cc_updates_panel_finalize;
+  object_class->set_property = cc_updates_panel_set_property;
+
+  g_object_class_override_property (object_class, PROP_PARAMETERS, "parameters");
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/updates/cc-updates-panel.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, automatic_updates_container);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, automatic_updates_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, metered_data_label);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, network_name_label);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, network_settings_label);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, network_status_icon);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, scheduled_updates_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcUpdatesPanel, tariff_editor);
+
+  gtk_widget_class_bind_template_callback (widget_class, on_automatic_updates_switch_changed_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_change_network_link_activated_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_scheduled_updates_switch_changed_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_tariff_changed_cb);
+
+  g_type_ensure (CC_TYPE_TARIFF_EDITOR);
+}
+
+static void
+cc_updates_panel_init (CcUpdatesPanel *self)
+{
+  g_autofree gchar *settings_text = NULL;
+
+  g_resources_register (cc_updates_get_resource ());
+
+  gtk_widget_init_template (GTK_WIDGET (self));
+
+  /* "Change Network Settings" label */
+  settings_text = g_strdup_printf ("<a href=\"\">%s</a>", _("Change Network Settings…"));
+  gtk_label_set_markup (GTK_LABEL (self->network_settings_label), settings_text);
+
+  /* Load any saved tariff */
+  load_tariff (self);
+
+  /* Setup network manager */
+  self->nm_client = nm_client_new (NULL, NULL);
+
+  update_active_network (self);
+
+  g_signal_connect_swapped (self->nm_client, "notify", G_CALLBACK (on_network_changed_cb), self);
+}

--- a/panels/updates/cc-updates-panel.h
+++ b/panels/updates/cc-updates-panel.h
@@ -1,0 +1,33 @@
+/* cc-updates-panel.h
+ *
+ * Copyright © 2018 Endless, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Georges Basile Stavracas Neto <georges@endlessm.com>
+ */
+
+#pragma once
+
+#include <shell/cc-panel.h>
+
+G_BEGIN_DECLS
+
+#define CC_TYPE_UPDATES_PANEL (cc_updates_panel_get_type())
+
+G_DECLARE_FINAL_TYPE (CcUpdatesPanel, cc_updates_panel, CC, UPDATES_PANEL, CcPanel)
+
+CcUpdatesPanel *cc_updates_panel_new (void);
+
+G_END_DECLS

--- a/panels/updates/cc-updates-panel.ui
+++ b/panels/updates/cc-updates-panel.ui
@@ -193,7 +193,7 @@
 
                 <!-- Schedule Updates section -->
                 <child>
-                  <object class="GtkFrame">
+                  <object class="GtkFrame" id="scheduled_updates_container">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="sensitive" bind-source="automatic_updates_switch" bind-property="active" bind-flags="default|sync-create" />

--- a/panels/updates/cc-updates-panel.ui
+++ b/panels/updates/cc-updates-panel.ui
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="CcUpdatesPanel" parent="CcPanel">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkScrolledWindow">
+        <property name="visible">True</property>
+        <property name="hscrollbar_policy">never</property>
+
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">18</property>
+            <property name="margin">32</property>
+            <property name="hexpand">True</property>
+            <property name="width-request">300</property>
+
+            <!--
+              Stub boxes to pull the widgets to the middle, and yet allow them to
+              grow and cover a third of the available space
+            -->
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="hexpand">True</property>
+              </object>
+            </child>
+
+            <!-- Content -->
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">18</property>
+
+                <!-- Device header -->
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="column-spacing">12</property>
+                        <property name="margin">18</property>
+
+                        <child>
+                          <object class="GtkImage" id="network_status_icon">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="pixel_size">48</property>
+                            <property name="icon_name">network-wireless-symbolic</property>
+                            <style>
+                              <class name="dim-label" />
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
+                            <property name="height">2</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel" id="network_name_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0.0</property>
+                            <property name="yalign">1.0</property>
+                            <property name="label">Network name</property>
+                            <attributes>
+                              <attribute name="scale" value="1.2" />
+                              <attribute name="weight" value="bold" />
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel" id="metered_data_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0.0</property>
+                            <property name="yalign">0.0</property>
+                            <property name="wrap">True</property>
+                            <style>
+                              <class name="dim-label" />
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel" id="network_settings_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="xalign">0.0</property>
+                            <signal name="activate-link" handler="on_change_network_link_activated_cb" object="CcUpdatesPanel" swapped="no" />
+                          </object>
+                          <packing>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">2</property>
+                            <property name="height">2</property>
+                          </packing>
+                        </child>
+
+                      </object>
+                    </child>
+                  </object>
+                </child>
+
+                <!-- Automatic Updates section -->
+                <child>
+                  <object class="GtkFrame" id="automatic_updates_container">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <style>
+                      <class name="view" />
+                    </style>
+
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="column-spacing">12</property>
+                        <property name="margin">18</property>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0.0</property>
+                            <property name="label" translatable="yes">Automatic Updates</property>
+                            <attributes>
+                              <attribute name="scale" value="1.2" />
+                              <attribute name="weight" value="bold" />
+                            </attributes>
+                          </object>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0.0</property>
+                            <property name="label" translatable="yes">Allow system and application updates to happen automatically without your request in the background.</property>
+                            <property name="wrap">True</property>
+                            <style>
+                              <class name="dim-label" />
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkSwitch" id="automatic_updates_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">start</property>
+                            <signal name="notify::active" handler="on_automatic_updates_switch_changed_cb" object="CcUpdatesPanel" swapped="no" />
+                          </object>
+                          <packing>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
+                            <property name="height">2</property>
+                          </packing>
+                        </child>
+
+                      </object>
+                    </child>
+                  </object>
+                </child>
+
+                <!-- Schedule Updates section -->
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="sensitive" bind-source="automatic_updates_switch" bind-property="active" bind-flags="default|sync-create" />
+                    <style>
+                      <class name="view" />
+                    </style>
+
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="column-spacing">12</property>
+                        <property name="margin">18</property>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0.0</property>
+                            <property name="label" translatable="yes">Scheduled Updates</property>
+                            <attributes>
+                              <attribute name="scale" value="1.2" />
+                              <attribute name="weight" value="bold" />
+                            </attributes>
+                          </object>
+                        </child>
+
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0.0</property>
+                            <property name="label" translatable="yes">Create a daily window for updates to happen automatically.</property>
+                            <property name="wrap">True</property>
+                            <style>
+                              <class name="dim-label" />
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
+                          </packing>
+                        </child>
+
+                        <child>
+                          <object class="GtkSwitch" id="scheduled_updates_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">start</property>
+                            <signal name="notify::active" handler="on_scheduled_updates_switch_changed_cb" object="CcUpdatesPanel" swapped="no" />
+                          </object>
+                          <packing>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
+                            <property name="height">2</property>
+                          </packing>
+                        </child>
+
+                        <!-- Period widgets -->
+                        <child>
+                          <object class="GtkRevealer">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="transition-type">slide-down</property>
+                            <property name="reveal-child" bind-source="scheduled_updates_switch" bind-property="active" bind-flags="default" />
+
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="spacing">18</property>
+                                <property name="margin-top">18</property>
+                                <property name="orientation">vertical</property>
+
+                                <child>
+                                  <object class="GtkSeparator">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                  </object>
+                                </child>
+
+                                <child>
+                                  <object class="CcTariffEditor" id="tariff_editor">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">center</property>
+                                    <signal name="tariff-changed" handler="on_tariff_changed_cb" object="CcUpdatesPanel" swapped="no" />
+                                  </object>
+                                </child>
+
+                              </object>
+                            </child>
+
+                          </object>
+                          <packing>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">0</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+
+                      </object>
+                    </child>
+                  </object>
+                </child>
+
+              </object>
+            </child>
+
+            <!--
+              Stub boxes to pull the widgets to the middle, and yet allow them to
+              grow and cover a third of the available space
+            -->
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="hexpand">True</property>
+              </object>
+            </child>
+
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/panels/updates/gnome-updates-panel.desktop.in.in
+++ b/panels/updates/gnome-updates-panel.desktop.in.in
@@ -1,0 +1,17 @@
+[Desktop Entry]
+_Name=Automatic Updates
+_Comment=Schedule automatic updates
+Exec=gnome-control-center updates
+Icon=software-update-available
+Terminal=false
+Type=Application
+NoDisplay=true
+StartupNotify=true
+Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
+OnlyShowIn=GNOME;Unity;
+X-GNOME-Bugzilla-Bugzilla=GNOME
+X-GNOME-Bugzilla-Product=gnome-control-center
+X-GNOME-Bugzilla-Component=updates
+X-GNOME-Bugzilla-Version=@VERSION@
+# Translators: those are keywords for the automatic updates control-center panel
+_Keywords=Updates;Automatic;

--- a/panels/updates/updates.gresource.xml
+++ b/panels/updates/updates.gresource.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/gnome/control-center/updates">
+    <file preprocess="xml-stripblanks">cc-tariff-editor.ui</file>
+    <file preprocess="xml-stripblanks">cc-updates-panel.ui</file>
+  </gresource>
+</gresources>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -195,6 +195,10 @@ panels/universal-access/gnome-universal-access-panel.desktop.in.in
 [type: gettext/glade]panels/universal-access/uap.ui
 panels/universal-access/zoom-options.c
 [type: gettext/glade]panels/universal-access/zoom-options.ui
+[type: gettext/glade]panels/updates/cc-tariff-editor.ui
+panels/updates/cc-updates-panel.c
+[type: gettext/glade]panels/updates/cc-updates-panel.ui
+panels/updates/gnome-updates-panel.desktop.in.in
 [type: gettext/glade]panels/user-accounts/data/account-dialog.ui
 [type: gettext/glade]panels/user-accounts/data/account-fingerprint.ui
 panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -27,6 +27,7 @@ panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in
 panels/sound/data/gnome-sound-panel.desktop.in
 panels/sound/data/sounds/gnome-sounds-default.xml.in
 panels/universal-access/gnome-universal-access-panel.desktop.in
+panels/updates/gnome-updates-panel.desktop.in
 panels/user-accounts/data/gnome-user-accounts-panel.desktop.in
 panels/user-accounts/fingerprint-strings.h
 panels/wacom/gnome-wacom-panel.desktop.in
@@ -58,6 +59,7 @@ sub/panels/sharing/org.gnome.controlcenter.remote-login-helper.policy.in
 sub/panels/sound/data/gnome-sound-panel.desktop.in
 sub/panels/sound/data/sounds/gnome-sounds-default.xml.in
 sub/panels/universal-access/gnome-universal-access-panel.desktop.in
+sub/panels/updates/gnome-updates-panel.desktop.in
 sub/panels/user-accounts/data/gnome-user-accounts-panel.desktop.in
 sub/panels/wacom/gnome-wacom-panel.desktop.in
 sub/shell/gnome-control-center.desktop.in

--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS =					\
 	$(SHELL_CFLAGS)				\
 	$(CHEESE_CFLAGS)			\
 	$(WACOM_PANEL_CFLAGS)			\
+	$(UPDATES_PANEL_CFLAGS)			\
 	-I$(top_srcdir)/panels/common/		\
 	-I$(top_srcdir)/shell/alt		\
 	-I$(top_srcdir)/libgd
@@ -108,6 +109,10 @@ endif
 
 if BUILD_BLUETOOTH
 gnome_control_center_LDADD += $(top_builddir)/panels/bluetooth/libbluetooth.la
+endif
+
+if BUILD_UPDATES
+gnome_control_center_LDADD += $(top_builddir)/panels/updates/libupdates.la
 endif
 
 gnome_control_center_alt_LDADD = 					\

--- a/shell/cc-panel-list.c
+++ b/shell/cc-panel-list.c
@@ -287,6 +287,7 @@ static const gchar * const panel_order[] = {
   "sound",
   "power",
   "network",
+  "updates",
 
   /* Devices page */
   "printers",

--- a/shell/cc-panel-loader.c
+++ b/shell/cc-panel-loader.c
@@ -56,6 +56,7 @@ extern GType cc_search_panel_get_type (void);
 extern GType cc_sharing_panel_get_type (void);
 extern GType cc_sound_panel_get_type (void);
 extern GType cc_ua_panel_get_type (void);
+extern GType cc_updates_panel_get_type (void);
 extern GType cc_user_panel_get_type (void);
 #ifdef BUILD_WACOM
 extern GType cc_wacom_panel_get_type (void);
@@ -102,6 +103,7 @@ static struct {
   PANEL_TYPE("sharing",          cc_sharing_panel_get_type      ),
   PANEL_TYPE("sound",            cc_sound_panel_get_type        ),
   PANEL_TYPE("universal-access", cc_ua_panel_get_type           ),
+  PANEL_TYPE("updates",          cc_updates_panel_get_type      ),
   PANEL_TYPE("user-accounts",    cc_user_panel_get_type         ),
 #ifdef BUILD_WACOM
   PANEL_TYPE("wacom",            cc_wacom_panel_get_type        ),


### PR DESCRIPTION
**Do not merge this yet; only for review until the rebase is finished.**

The Automatic Updates panel is a new panel that manages two
different settings:

 1. Whether updates should happen automatically or not
 2. A period where updates are allowed to happen

The first setting is implemented on a per-connection fashion,
using NetworkManager's ability to store user data on specific
connections. In this case, the property being set is:

  connection.allow-downloads-when-metered

The second setting is slightly trickier to implement, and uses
libmogwai-tariff to load and store a simple tariff. This tariff
has the following layout:

  i. Base tariff, downloads are forbidden, spans from 0 to forever.
 ii. Recurrent tariff, downloads are completely allowed, spans
     from [start hour] to [end hour]. If [start hour] >= [end hour],
     then [end hour] is contained in the following day.

This tariff schedule, when changed, is saved every 2 seconds, to
avoid abusing I/O.

https://phabricator.endlessm.com/T20818