### PR TITLE
display: Add a method to retrieve the name of a monitor mode

### DIFF
--- a/panels/display/cc-display-config-dbus.c
+++ b/panels/display/cc-display-config-dbus.c
@@ -22,7 +22,7 @@
 
 #include "cc-display-config-dbus.h"
 
-#define MODE_BASE_FORMAT "siiddad"
+#define MODE_BASE_FORMAT "ssiiddad"
 #define MODE_FORMAT "(" MODE_BASE_FORMAT "a{sv})"
 #define MODES_FORMAT "a" MODE_FORMAT
 #define MONITOR_SPEC_FORMAT "(ssss)"
@@ -47,6 +47,7 @@ struct _CcDisplayModeDBus
   CcDisplayMode parent_instance;
 
   char *id;
+  char *name;
   int width;
   int height;
   double refresh_rate;
@@ -71,6 +72,14 @@ cc_display_mode_dbus_equal (const CcDisplayModeDBus *m1,
   return m1->width == m2->width &&
     m1->height == m2->height &&
     m1->refresh_rate == m2->refresh_rate;
+}
+
+static const char *
+cc_display_mode_dbus_get_name (CcDisplayMode *pself)
+{
+  CcDisplayModeDBus *self = CC_DISPLAY_MODE_DBUS (pself);
+
+  return self->name;
 }
 
 static void
@@ -151,6 +160,7 @@ cc_display_mode_dbus_finalize (GObject *object)
   CcDisplayModeDBus *self = CC_DISPLAY_MODE_DBUS (object);
 
   g_free (self->id);
+  g_free (self->name);
   g_array_free (self->supported_scales, TRUE);
 
   G_OBJECT_CLASS (cc_display_mode_dbus_parent_class)->finalize (object);
@@ -164,6 +174,7 @@ cc_display_mode_dbus_class_init (CcDisplayModeDBusClass *klass)
 
   gobject_class->finalize = cc_display_mode_dbus_finalize;
 
+  parent_class->get_name = cc_display_mode_dbus_get_name;
   parent_class->get_resolution = cc_display_mode_dbus_get_resolution;
   parent_class->get_supported_scales = cc_display_mode_dbus_get_supported_scales;
   parent_class->get_preferred_scale = cc_display_mode_dbus_get_preferred_scale;
@@ -185,6 +196,7 @@ cc_display_mode_dbus_new (GVariant *variant)
 
   g_variant_get (variant, "(" MODE_BASE_FORMAT "@a{sv})",
                  &self->id,
+                 &self->name,
                  &self->width,
                  &self->height,
                  &self->refresh_rate,

--- a/panels/display/cc-display-config.c
+++ b/panels/display/cc-display-config.c
@@ -33,6 +33,12 @@ cc_display_mode_class_init (CcDisplayModeClass *klass)
 {
 }
 
+const char *
+cc_display_mode_get_name (CcDisplayMode *self)
+{
+  return CC_DISPLAY_MODE_GET_CLASS (self)->get_name (self);
+}
+
 void
 cc_display_mode_get_resolution (CcDisplayMode *self, int *w, int *h)
 {

--- a/panels/display/cc-display-config.h
+++ b/panels/display/cc-display-config.h
@@ -78,6 +78,7 @@ struct _CcDisplayModeClass
 {
   GObjectClass parent_class;
 
+  const char * (*get_name) (CcDisplayMode *self);
   void (*get_resolution) (CcDisplayMode *self, int *w, int *h);
   const double * (*get_supported_scales) (CcDisplayMode *self);
   double (*get_preferred_scale) (CcDisplayMode *self);
@@ -184,6 +185,8 @@ void cc_display_monitor_set_mode (CcDisplayMonitor *monitor,
                                   CcDisplayMode    *mode);
 void cc_display_monitor_set_position (CcDisplayMonitor *monitor,
                                       int x, int y);
+
+const char * cc_display_mode_get_name (CcDisplayMode *mode);
 
 void cc_display_mode_get_resolution (CcDisplayMode *mode,
                                      int *width,

--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -3083,14 +3083,20 @@ make_resolution_string (CcDisplayMode *mode)
   const char *interlaced = cc_display_mode_is_interlaced (mode) ? "i" : "";
   const char *aspect;
   int width, height;
+  const char *name;
 
   cc_display_mode_get_resolution (mode, &width, &height);
   aspect = make_aspect_string (width, height);
 
+  /* Retrieve the name assigned by mutter if possible, so that we
+   * show a non-confusing string to the user when underscanning.
+   */
+  name = cc_display_mode_get_name (mode);
+
   if (aspect != NULL)
-    return g_strdup_printf ("%d × %d%s (%s)", width, height, interlaced, aspect);
+    return g_strdup_printf ("%s%s (%s)", name, interlaced, aspect);
   else
-    return g_strdup_printf ("%d × %d%s", width, height, interlaced);
+    return g_strdup_printf ("%s%s", name, interlaced);
 }
 
 static const gchar *


### PR DESCRIPTION
This will use the GetCurrentState method from org.gnome.mutter.DisplayConfig
under the hood, which we have modified to expose a human-friendly name for
a given mode, accounting for underscanning in case it's enabled.

The idea is to always show things such as "1920x1080" regardless of whether
underscanning is on, instead of confusing things such as "1824x1026".

https://phabricator.endlessm.com/T20655