### PR TITLE
sharing: fix case in content sharing description

### DIFF
--- a/panels/sharing/sharing.ui
+++ b/panels/sharing/sharing.ui
@@ -933,7 +933,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Content Sharing allows users to view content installed on this computer on Android Devices on the same Network.</property>
+                <property name="label" translatable="yes">Content sharing allows users to view content installed on this computer on Android devices on the same network.</property>
                 <property name="max-width-chars">50</property>
                 <property name="wrap">True</property>
               </object>


### PR DESCRIPTION
This is a sentence, so it should use sentence case, where only proper nouns like “Android” are capitalized mid-sentence.

I accept that other descriptions throughout the control center are not consistent on this point. Some, but not all, follow the convention where the name of the feature is in Title Case. Regardless, “Devices” and “Network” should certainly not be capitalized.

https://phabricator.endlessm.com/T20381
https://phabricator.endlessm.com/T20668