### PR TITLE
display: Early return in monitor_labeler_show() if no outputs are available

### DIFF
--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -208,13 +208,16 @@ monitor_labeler_show (CcDisplayPanel *self)
   if (!priv->shell_proxy || !priv->current_config)
     return;
 
+  outputs = g_object_get_data (G_OBJECT (priv->current_config), "ui-sorted-outputs");
+  if (!outputs)
+    return;
+
   if (cc_display_config_is_cloning (priv->current_config))
     return monitor_labeler_hide (self);
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE_TUPLE);
   g_variant_builder_open (&builder, G_VARIANT_TYPE_ARRAY);
 
-  outputs = g_object_get_data (G_OBJECT (priv->current_config), "ui-sorted-outputs");
   for (l = outputs; l != NULL; l = l->next)
     {
       CcDisplayMonitor *output = l->data;


### PR DESCRIPTION
The GVariant constructed here would be useless otherwise, since there are
no outputs to show the labels for. Besides, calling g_variant_builder_close
in this scenario would hit an assertion and the program would crash.

https://gitlab.gnome.org/GNOME/gnome-control-center/issues/12

https://phabricator.endlessm.com/T20655