### PR TITLE
Don't declare StartupNotify=true in panel-specific desktop files

### DIFF
--- a/panels/background/gnome-background-panel.desktop.in.in
+++ b/panels/background/gnome-background-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-desktop-wallpaper
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;
 # Translators: those are keywords for the background control-center panel

--- a/panels/bluetooth/gnome-bluetooth-panel.desktop.in.in
+++ b/panels/bluetooth/gnome-bluetooth-panel.desktop.in.in
@@ -9,7 +9,6 @@ Type=Application
 NoDisplay=true
 Categories=GTK;GNOME;Settings;X-GNOME-NetworkSettings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-ConnectivitySettings;
 OnlyShowIn=GNOME;Unity;
-StartupNotify=true
 X-GNOME-Bugzilla-Bugzilla=GNOME
 X-GNOME-Bugzilla-Product=gnome-bluetooth
 X-GNOME-Bugzilla-Component=properties

--- a/panels/color/gnome-color-panel.desktop.in.in
+++ b/panels/color/gnome-color-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-color
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-Settings-Panel;HardwareSettings;X-GNOME-DevicesSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/datetime/gnome-datetime-panel.desktop.in.in
+++ b/panels/datetime/gnome-datetime-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-system-time
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;X-GNOME-DetailsSettings;
 OnlyShowIn=GNOME;
 # Translators: those are keywords for the date and time control-center panel

--- a/panels/display/gnome-display-panel.desktop.in.in
+++ b/panels/display/gnome-display-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-desktop-display
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-DevicesSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/info/gnome-default-apps-panel.desktop.in.in
+++ b/panels/info/gnome-default-apps-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=starred
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-Hidden;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;X-GNOME-DetailsSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/info/gnome-info-overview-panel.desktop.in.in
+++ b/panels/info/gnome-info-overview-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=help-about
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-Hidden;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;X-GNOME-DetailsSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/info/gnome-info-panel.desktop.in.in
+++ b/panels/info/gnome-info-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=applications-system
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-AltHidden;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;X-GNOME-DetailsSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/info/gnome-removable-media-panel.desktop.in.in
+++ b/panels/info/gnome-removable-media-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=media-removable
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-Hidden;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;X-GNOME-DevicesSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/keyboard/gnome-keyboard-panel.desktop.in.in
+++ b/panels/keyboard/gnome-keyboard-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=input-keyboard
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-DevicesSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/mouse/gnome-mouse-panel.desktop.in.in
+++ b/panels/mouse/gnome-mouse-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=input-mouse
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-DevicesSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/network/gnome-network-panel.desktop.in.in
+++ b/panels/network/gnome-network-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=network-workgroup
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/network/gnome-wifi-panel.desktop.in.in
+++ b/panels/network/gnome-wifi-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=network-wireless
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-ConnectivitySettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/notifications/gnome-notifications-panel.desktop.in.in
+++ b/panels/notifications/gnome-notifications-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-system-notifications
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/online-accounts/gnome-online-accounts-panel.desktop.in.in
+++ b/panels/online-accounts/gnome-online-accounts-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=goa-panel
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;X-GNOME-AccountSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/power/gnome-power-panel.desktop.in.in
+++ b/panels/power/gnome-power-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=gnome-power-manager
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;HardwareSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/printers/gnome-printers-panel.desktop.in.in
+++ b/panels/printers/gnome-printers-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=printer
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 # The X-GNOME-Settings-Panel is necessary to show in the main shell UI
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-DevicesSettings;
 OnlyShowIn=GNOME;Unity;

--- a/panels/privacy/gnome-privacy-panel.desktop.in.in
+++ b/panels/privacy/gnome-privacy-panel.desktop.in.in
@@ -8,7 +8,6 @@ Icon=preferences-system-privacy
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;X-GNOME-AccountSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/region/gnome-region-panel.desktop.in.in
+++ b/panels/region/gnome-region-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-desktop-locale
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/search/gnome-search-panel.desktop.in.in
+++ b/panels/search/gnome-search-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-system-search
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalSettings;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/sharing/gnome-sharing-panel.desktop.in.in
+++ b/panels/sharing/gnome-sharing-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-system-sharing
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-SystemSettings;X-GNOME-AccountSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Settings-Panel=sharing

--- a/panels/sound/data/gnome-sound-panel.desktop.in.in
+++ b/panels/sound/data/gnome-sound-panel.desktop.in.in
@@ -6,7 +6,6 @@ Icon=multimedia-volume-control
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/universal-access/gnome-universal-access-panel.desktop.in.in
+++ b/panels/universal-access/gnome-universal-access-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=preferences-desktop-accessibility
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;X-GNOME-PersonalizationSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/updates/gnome-updates-panel.desktop.in.in
+++ b/panels/updates/gnome-updates-panel.desktop.in.in
@@ -6,7 +6,6 @@ Icon=software-update-available
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in
+++ b/panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in
@@ -6,7 +6,6 @@ Icon=system-users
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=System;Settings;X-GNOME-Settings-Panel;X-GNOME-SystemSettings;X-GNOME-DetailsSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME

--- a/panels/wacom/gnome-wacom-panel.desktop.in.in
+++ b/panels/wacom/gnome-wacom-panel.desktop.in.in
@@ -7,7 +7,6 @@ Icon=input-tablet
 Terminal=false
 Type=Application
 NoDisplay=true
-StartupNotify=true
 Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-DevicesSettings;
 OnlyShowIn=GNOME;Unity;
 X-GNOME-Bugzilla-Bugzilla=GNOME


### PR DESCRIPTION
As per the Startup Notification Spec, when an application declares this
in its desktop file, it the launcher (e.g. the shell) will initiate the
startup process, expecting the launchee to finish it with a "remove" X
message once it's ready, unless there's a failure launching it.

The problem here is that this panel-specific desktop files declaring that
key confuses the shell, since it will make it initiate the startup process
but then no "remove" message is ever received if g-c-c was already running,
since the newly launched process will realize it's not the main instance and
will exit gracefully after handing over control of the situation to the
original process, with exit code 0, leaving the startup process unfinished.

Due to this, the shell will keep waiting for a supposedly new application
(as per the the panel-specific desktop file used to launch) to finish, which
will result in the cursor to keep spinning, and a rogue icon to keep showing
up in the taskbar, after the app is discarded by the shell on a timeout.

We should fix this in GLib, since apps that exit gracefully due to handing
control over to a previous instance should still send the "remove" message,
but in the meantime let's make our user's lives better by not declaring this
key in any of the panel-specific desktop files (it's ok to keep it in the
main desktop file though, since the shell won't be fooled in that case).

[1] https://www.freedesktop.org/wiki/Specifications/startup-notification-spec

https://phabricator.endlessm.com/T20609