### PR TITLE
T22384

### DIFF
--- a/panels/updates/cc-tariff-editor.c
+++ b/panels/updates/cc-tariff-editor.c
@@ -91,28 +91,24 @@ update_seconds_from_adjustments (CcTariffEditor *self)
 {
   g_autoptr(GDateTime) local_start = NULL;
   g_autoptr(GDateTime) local_end = NULL;
-  guint factor_from = 0;
-  guint factor_to = 0;
+  gint minute_start = 0;
+  gint minute_end = 0;
+  gint hour_start = 0;
+  gint hour_end = 0;
+
+  hour_start = (gint) gtk_adjustment_get_value (self->adjustment_from_hours);
+  hour_end = (gint) gtk_adjustment_get_value (self->adjustment_to_hours);
+  minute_start = (gint) gtk_adjustment_get_value (self->adjustment_from_minutes);
+  minute_end = (gint) gtk_adjustment_get_value (self->adjustment_to_minutes);
 
   if (self->clock_format == G_DESKTOP_CLOCK_FORMAT_12H)
     {
-      factor_from = self->time_period_from == AM ? 0 : 12;
-      factor_to = self->time_period_to == AM ? 0 : 12;
+      hour_start = hour_start % 12 + (self->time_period_from == AM ? 0 : 12);
+      hour_end = hour_end % 12 + (self->time_period_to == AM ? 0 : 12);
     }
 
-  local_start = g_date_time_new_local (1970,
-                                       1,
-                                       1,
-                                       gtk_adjustment_get_value (self->adjustment_from_hours) + factor_from,
-                                       gtk_adjustment_get_value (self->adjustment_from_minutes),
-                                       0);
-
-  local_end = g_date_time_new_local (1970,
-                                     1,
-                                     1,
-                                     gtk_adjustment_get_value (self->adjustment_to_hours) + factor_to,
-                                     gtk_adjustment_get_value (self->adjustment_to_minutes),
-                                     0);
+  local_start = g_date_time_new_local (1970, 1, 1, hour_start, minute_start, 0);
+  local_end = g_date_time_new_local (1970, 1, 1, hour_end, minute_end, 0);
 
   /*
    * If 'from' > 'to', e.g. [22:15, 05:45), this period is crossing days and we


### PR DESCRIPTION
12h clock formats have the peculiarity of mapping 12 to 0, no
matter if AM or PM. On 12h systems, whenever we need to convert
from 12h to 24h clock format - a common operation when dealing
with GDateTime, since it only understands 24h times - it is
essential to convert transform 12 into 0.

The current code doesn't do that, and tries to create a GDateTime
with 24:00 under some circumstances. The maximum time that can be
represented in GDateTime is 23:59, and this failed attempt would
result in a crash.

To fix that, the hour is now moduled by 12. In order to keep the
code legibility, the hours and minutes are now stored into separate
variables.

This modification only affects systems with 12h clock formats.

https://phabricator.endlessm.com/T22384