### PR TITLE
wifi: show generic "network" help page

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "panels/sound/gvc"]
 	path = panels/sound/gvc
-	url = git://git.gnome.org/libgnome-volume-control
+	url = https://gitlab.gnome.org/GNOME/libgnome-volume-control.git
 
 [submodule "libgd"]
 	path = libgd
-	url = git://git.gnome.org/libgd
+	url = https://gitlab.gnome.org/GNOME/libgd.git

--- a/panels/network/cc-wifi-panel.c
+++ b/panels/network/cc-wifi-panel.c
@@ -465,7 +465,7 @@ rfkill_switch_notify_activate_cb (GtkSwitch   *rfkill_switch,
 static const gchar *
 cc_wifi_panel_get_help_uri (CcPanel *panel)
 {
-  return "help:gnome-help/net-wireless";
+  return "help:gnome-help/net#connecting";
 }
 
 static GtkWidget *


### PR DESCRIPTION
Our help pages are forked from GNOME 3.10, and don't have a net-wireless
page.

https://phabricator.endlessm.com/T23340