### PR TITLE
power: Label the PENDING_CHARGING state as "Not Charging" 

### DIFF
--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -286,7 +286,6 @@ get_details_string (gdouble percentage, UpDeviceState state, guint64 time)
       switch (state)
         {
           case UP_DEVICE_STATE_CHARGING:
-          case UP_DEVICE_STATE_PENDING_CHARGE:
             /* TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes" */
             details = g_strdup_printf (_("%s until fully charged"), time_string);
             break;
@@ -307,6 +306,10 @@ get_details_string (gdouble percentage, UpDeviceState state, guint64 time)
             /* TRANSLATORS: primary battery */
             details = g_strdup (_("Fully charged"));
             break;
+          case UP_DEVICE_STATE_PENDING_CHARGE:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Not charging"));
+            break;
           case UP_DEVICE_STATE_EMPTY:
             /* TRANSLATORS: primary battery */
             details = g_strdup (_("Empty"));
@@ -322,7 +325,6 @@ get_details_string (gdouble percentage, UpDeviceState state, guint64 time)
       switch (state)
         {
           case UP_DEVICE_STATE_CHARGING:
-          case UP_DEVICE_STATE_PENDING_CHARGE:
             /* TRANSLATORS: primary battery */
             details = g_strdup (_("Charging"));
             break;
@@ -334,6 +336,10 @@ get_details_string (gdouble percentage, UpDeviceState state, guint64 time)
           case UP_DEVICE_STATE_FULLY_CHARGED:
             /* TRANSLATORS: primary battery */
             details = g_strdup (_("Fully charged"));
+            break;
+          case UP_DEVICE_STATE_PENDING_CHARGE:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Not charging"));
             break;
           case UP_DEVICE_STATE_EMPTY:
             /* TRANSLATORS: primary battery */


### PR DESCRIPTION
The pending-charge state means AC power is on but the battery is not
being charged. This can happen because its charge is above a certain
threshold, to avoid short charging cycles and prolong the battery's
life, or because the PSU is not powerful enough to charge the batteries.

Instead of lying to the user about something being estimated, we should
simply tell the truth and set the label to "Not Charging".

https://phabricator.endlessm.com/T24044