### PR TITLE
rules: fix wrong vendor configuration file path

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ override_dh_auto_configure:
 		--libexecdir=\$${prefix}/lib/gnome-control-center \
 		--with-gnome-session-libexecdir=\$${prefix}/lib/gnome-session \
 		--disable-update-mimedb \
-		--with-vendor-conf-file=/var/eos-image-defaults/branding/gnome-control-center.conf
+		--with-vendor-conf-file=/var/lib/eos-image-defaults/branding/gnome-control-center.conf
 
 override_dh_missing:
 	dh_missing --fail-missing


### PR DESCRIPTION
This lives in /var/lib/eos-image-defaults, not /var/eos-image-defaults.
The wrong value was introduced with the rebase for 3.3, in June 2017,
and went unnoticed until now.
See https://github.com/endlessm/gnome-control-center/commit/987506c90192e69e43ff4e5b850e90abf8948cc1#diff-d2b2229a977ef7e99780f2207c29b503

https://phabricator.endlessm.com/T24422