### PR TITLE
panels: Add X-GNOME-UsesNotifications to several desktop files

### DIFF
--- a/panels/color/gnome-color-panel.desktop.in.in
+++ b/panels/color/gnome-color-panel.desktop.in.in
@@ -15,3 +15,5 @@ X-GNOME-Bugzilla-Component=color
 X-GNOME-Bugzilla-Version=@VERSION@
 # Translators: those are keywords for the color control-center panel
 _Keywords=Color;ICC;Profile;Calibrate;Printer;Display;
+# Notifications are emitted by gnome-settings-daemon
+X-GNOME-UsesNotifications=true

--- a/panels/datetime/gnome-datetime-panel.desktop.in.in
+++ b/panels/datetime/gnome-datetime-panel.desktop.in.in
@@ -11,3 +11,5 @@ Categories=GNOME;GTK;Settings;X-GNOME-SystemSettings;X-GNOME-Settings-Panel;X-GN
 OnlyShowIn=GNOME;
 # Translators: those are keywords for the date and time control-center panel
 _Keywords=Clock;Timezone;Location;
+# Notifications are emitted by gnome-settings-daemon
+X-GNOME-UsesNotifications=true

--- a/panels/power/gnome-power-panel.desktop.in.in
+++ b/panels/power/gnome-power-panel.desktop.in.in
@@ -15,3 +15,5 @@ X-GNOME-Bugzilla-Component=power
 X-GNOME-Bugzilla-Version=@VERSION@
 # Translators: those are keywords for the power control-center panel
 _Keywords=Power;Sleep;Suspend;Hibernate;Battery;Brightness;Dim;Blank;Monitor;DPMS;Idle;
+# Notifications are emitted by gnome-settings-daemon
+X-GNOME-UsesNotifications=true

--- a/panels/printers/gnome-printers-panel.desktop.in.in
+++ b/panels/printers/gnome-printers-panel.desktop.in.in
@@ -12,3 +12,5 @@ Categories=GNOME;GTK;Settings;HardwareSettings;X-GNOME-Settings-Panel;X-GNOME-De
 OnlyShowIn=GNOME;Unity;
 # Translators: those are keywords for the printing control-center panel
 _Keywords=Printer;Queue;Print;Paper;Ink;Toner;
+# Notifications are emitted by gnome-settings-daemon
+X-GNOME-UsesNotifications=true

--- a/panels/universal-access/gnome-universal-access-panel.desktop.in.in
+++ b/panels/universal-access/gnome-universal-access-panel.desktop.in.in
@@ -15,3 +15,5 @@ X-GNOME-Bugzilla-Component=Universal Access
 X-GNOME-Bugzilla-Version=@VERSION@
 # Translators: those are keywords for the universal access control-center panel
 _Keywords=Keyboard;Mouse;a11y;Accessibility;Contrast;Zoom;Screen;Reader;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Assist;Repeat;Blink;
+# Notifications are emitted by gnome-settings-daemon
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
gnome-settings-daemon emits notifications related to these five control
panels. If we add X-GNOME-UsesNotifications to their desktop files, the
user will be able to control the notifications.

(Backport to EOS: Support additional notification in
panels/universal-access.)

https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20990