### PR TITLE
Backport T23897 (Add App Permissions to User Accounts panel) to eos3.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,7 +184,9 @@ PKG_CHECK_MODULES(USER_ACCOUNTS_PANEL, $COMMON_MODULES
                   gnome-desktop-3.0
                   gdk-pixbuf-2.0 >= $GDKPIXBUF_REQUIRED_VERSION
                   pwquality >= $PWQUALITY_REQUIRED_VERSION
-                  accountsservice >= $ACCOUNTSSERVICE_REQUIRED_VERSION)
+                  accountsservice >= $ACCOUNTSSERVICE_REQUIRED_VERSION
+                  eos-parental-controls-0
+                  flatpak)
 PKG_CHECK_MODULES(SHARING_PANEL, $COMMON_MODULES flatpak)
 PKG_CHECK_MODULES(REMOTE_LOGIN_HELPER, glib-2.0 >= $GLIB_REQUIRED_VERSION gio-2.0)
 

--- a/panels/user-accounts/Makefile.am
+++ b/panels/user-accounts/Makefile.am
@@ -27,6 +27,8 @@ BUILT_SOURCES = \
 	um-resources.h
 
 libuser_accounts_la_SOURCES =		\
+	gs-content-rating.h		\
+	gs-content-rating.c		\
 	um-account-type.h		\
 	um-account-type.c 		\
 	um-account-dialog.h		\
@@ -58,6 +60,8 @@ libuser_accounts_la_SOURCES =		\
 	um-user-image.c			\
 	um-cell-renderer-user-image.h	\
 	um-cell-renderer-user-image.c	\
+	um-app-permissions.h		\
+	um-app-permissions.c		\
 	$(BUILT_SOURCES)
 
 libuser_accounts_la_LIBADD = 		\

--- a/panels/user-accounts/data/app-permissions.ui
+++ b/panels/user-accounts/data/app-permissions.ui
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="UmAppPermissions" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="margin-top">18</property>
+    <property name="row-spacing">6</property>
+    <property name="column-spacing">12</property>
+    <property name="valign">start</property>
+
+    <!-- Restricted Apps -->
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="xalign">0.0</property>
+        <property name="label" translatable="yes">Restrict Apps</property>
+        <attributes>
+          <attribute name="weight" value="bold" />
+        </attributes>
+      </object>
+      <packing>
+        <property name="top-attach">0</property>
+        <property name="left-attach">0</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="xalign">0.0</property>
+        <property name="label" translatable="yes">Prevent this user from opening some apps.</property>
+        <attributes>
+          <attribute name="scale" value="0.83333" />
+        </attributes>
+        <style>
+          <class name="dim-label" />
+        </style>
+      </object>
+      <packing>
+        <property name="top-attach">1</property>
+        <property name="left-attach">0</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkScrolledWindow">
+        <property name="visible">True</property>
+        <property name="hexpand">True</property>
+        <property name="hscrollbar-policy">never</property>
+        <property name="min-content-height">100</property>
+        <property name="max-content-height">400</property>
+        <property name="propagate-natural-height">True</property>
+        <property name="shadow-type">etched-in</property>
+
+        <!-- Restricted Apps Listbox -->
+        <child>
+          <object class="GtkListBox" id="listbox">
+            <property name="visible">True</property>
+            <property name="selection-mode">none</property>
+          </object>
+        </child>
+
+      </object>
+      <packing>
+        <property name="top-attach">2</property>
+        <property name="left-attach">0</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+
+    <!-- App Center Restrictions -->
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="margin-top">12</property>
+        <property name="xalign">0.0</property>
+        <property name="label" translatable="yes">App Center Restrictions</property>
+        <attributes>
+          <attribute name="weight" value="bold" />
+        </attributes>
+      </object>
+      <packing>
+        <property name="top-attach">3</property>
+        <property name="left-attach">0</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="spacing">12</property>
+
+        <child>
+          <object class="GtkLabel" id="user_installation_label">
+            <property name="visible">True</property>
+            <property name="xalign">1.0</property>
+            <property name="label" translatable="yes">App installation:</property>
+            <style>
+              <class name="dim-label" />
+            </style>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkSwitch" id="allow_user_installation_switch">
+            <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="halign">start</property>
+            <signal name="notify::active" handler="on_allow_installation_switch_active_changed_cb" object="UmAppPermissions" swapped="no" />
+          </object>
+        </child>
+
+      </object>
+      <packing>
+        <property name="top-attach">4</property>
+        <property name="left-attach">0</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="spacing">12</property>
+
+        <child>
+          <object class="GtkLabel" id="system_installation_label">
+            <property name="visible">True</property>
+            <property name="xalign">1.0</property>
+            <property name="label" translatable="yes">Installed apps can be used by every user:</property>
+            <style>
+              <class name="dim-label" />
+            </style>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkSwitch" id="allow_system_installation_switch">
+            <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="halign">start</property>
+            <signal name="notify::active" handler="on_allow_installation_switch_active_changed_cb" object="UmAppPermissions" swapped="no" />
+          </object>
+        </child>
+
+      </object>
+      <packing>
+        <property name="top-attach">5</property>
+        <property name="left-attach">0</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="spacing">12</property>
+
+        <child>
+          <object class="GtkLabel" id="app_restriction_label">
+            <property name="visible">True</property>
+            <property name="xalign">1.0</property>
+            <property name="label" translatable="yes">Show apps suitable for:</property>
+            <style>
+              <class name="dim-label" />
+            </style>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkMenuButton" id="restriction_button">
+            <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="halign">start</property>
+            <property name="popover">restriction_popover</property>
+            <property name="width-request">200</property>
+          </object>
+        </child>
+
+      </object>
+      <packing>
+        <property name="top-attach">6</property>
+        <property name="left-attach">0</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+
+  </template>
+
+  <object class="GtkPopoverMenu" id="restriction_popover" />
+  <menu id="age_menu" />
+
+  <object class="GtkSizeGroup">
+    <property name="mode">horizontal</property>
+    <widgets>
+      <widget name="restriction_button" />
+      <widget name="restriction_popover" />
+    </widgets>
+  </object>
+
+  <object class="GtkSizeGroup">
+    <property name="mode">horizontal</property>
+    <widgets>
+      <widget name="app_restriction_label" />
+      <widget name="user_installation_label" />
+      <widget name="system_installation_label" />
+    </widgets>
+  </object>
+</interface>
+

--- a/panels/user-accounts/data/user-accounts-dialog.ui
+++ b/panels/user-accounts/data/user-accounts-dialog.ui
@@ -415,6 +415,20 @@
                     <property name="height">1</property>
                   </packing>
                 </child>
+
+                <!-- App Permissions -->
+                <child>
+                  <object class="UmAppPermissions" id="app-permissions">
+                    <property name="visible">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">7</property>
+                    <property name="width">3</property>
+                    <property name="height">1</property>
+                  </packing>
+                </child>
+
               </object>
             </child>
             <child>

--- a/panels/user-accounts/gs-content-rating.c
+++ b/panels/user-accounts/gs-content-rating.c
@@ -1,0 +1,869 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2015-2016 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+
+#include "gs-content-rating.h"
+
+const gchar *
+gs_content_rating_system_to_str (GsContentRatingSystem system)
+{
+	if (system == GS_CONTENT_RATING_SYSTEM_INCAA)
+		return "INCAA";
+	if (system == GS_CONTENT_RATING_SYSTEM_ACB)
+		return "ACB";
+	if (system == GS_CONTENT_RATING_SYSTEM_DJCTQ)
+		return "DJCTQ";
+	if (system == GS_CONTENT_RATING_SYSTEM_GSRR)
+		return "GSRR";
+	if (system == GS_CONTENT_RATING_SYSTEM_PEGI)
+		return "PEGI";
+	if (system == GS_CONTENT_RATING_SYSTEM_KAVI)
+		return "KAVI";
+	if (system == GS_CONTENT_RATING_SYSTEM_USK)
+		return "USK";
+	if (system == GS_CONTENT_RATING_SYSTEM_ESRA)
+		return "ESRA";
+	if (system == GS_CONTENT_RATING_SYSTEM_CERO)
+		return "CERO";
+	if (system == GS_CONTENT_RATING_SYSTEM_OFLCNZ)
+		return "OFLCNZ";
+	if (system == GS_CONTENT_RATING_SYSTEM_RUSSIA)
+		return "RUSSIA";
+	if (system == GS_CONTENT_RATING_SYSTEM_MDA)
+		return "MDA";
+	if (system == GS_CONTENT_RATING_SYSTEM_GRAC)
+		return "GRAC";
+	if (system == GS_CONTENT_RATING_SYSTEM_ESRB)
+		return "ESRB";
+	if (system == GS_CONTENT_RATING_SYSTEM_IARC)
+		return "IARC";
+	return NULL;
+}
+
+const gchar *
+gs_content_rating_key_value_to_str (const gchar *id, EpcAppFilterOarsValue value)
+{
+	guint i;
+	const struct {
+		const gchar		*id;
+		EpcAppFilterOarsValue	 value;
+		const gchar		*desc;
+	} tab[] =  {
+	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No cartoon violence") },
+	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Cartoon characters in unsafe situations") },
+	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Cartoon characters in aggressive conflict") },
+	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic violence involving cartoon characters") },
+	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No fantasy violence") },
+	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Characters in unsafe situations easily distinguishable from reality") },
+	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Characters in aggressive conflict easily distinguishable from reality") },
+	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic violence easily distinguishable from reality") },
+	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No realistic violence") },
+	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Mildly realistic characters in unsafe situations") },
+	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Depictions of realistic characters in aggressive conflict") },
+	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic violence involving realistic characters") },
+	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No bloodshed") },
+	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Unrealistic bloodshed") },
+	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Realistic bloodshed") },
+	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Depictions of bloodshed and the mutilation of body parts") },
+	{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No sexual violence") },
+	{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Rape or other violent sexual behavior") },
+	{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references to alcohol") },
+	{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("References to alcoholic beverages") },
+	{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Use of alcoholic beverages") },
+	{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references to illicit drugs") },
+	{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("References to illicit drugs") },
+	{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Use of illicit drugs") },
+	{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("References to tobacco products") },
+	{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Use of tobacco products") },
+	{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No nudity of any sort") },
+	{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Brief artistic nudity") },
+	{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Prolonged nudity") },
+	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references or depictions of sexual nature") },
+	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Provocative references or depictions") },
+	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Sexual references or depictions") },
+	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic sexual behavior") },
+	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No profanity of any kind") },
+	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Mild or infrequent use of profanity") },
+	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Moderate use of profanity") },
+	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Strong or frequent use of profanity") },
+	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No inappropriate humor") },
+	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Slapstick humor") },
+	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Vulgar or bathroom humor") },
+	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Mature or sexual humor") },
+	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No discriminatory language of any kind") },
+	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Negativity towards a specific group of people") },
+	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Discrimination designed to cause emotional harm") },
+	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Explicit discrimination based on gender, sexuality, race or religion") },
+	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No advertising of any kind") },
+	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Product placement") },
+	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Explicit references to specific brands or trademarked products") },
+	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Users are encouraged to purchase specific real-world items") },
+	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No gambling of any kind") },
+	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Gambling on random events using tokens or credits") },
+	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Gambling using “play” money") },
+	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Gambling using real money") },
+	{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No ability to spend money") },
+	{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_MILD,		/* v1.1 */
+	/* TRANSLATORS: content rating description */
+	_("Users are encouraged to donate real money") },
+	{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Ability to spend real money in-game") },
+	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No way to chat with other users") },
+	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("User-to-user game interactions without chat functionality") },
+	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Moderated chat functionality between users") },
+	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Uncontrolled chat functionality between users") },
+	{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No way to talk with other users") },
+	{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Uncontrolled audio or video chat functionality between users") },
+	{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No sharing of social network usernames or email addresses") },
+	{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Sharing social network usernames or email addresses") },
+	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No sharing of user information with 3rd parties") },
+	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MILD,		/* v1.1 */
+	/* TRANSLATORS: content rating description */
+	_("Checking for the latest application version") },
+	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	/* v1.1 */
+	/* TRANSLATORS: content rating description */
+	_("Sharing diagnostic data that does not let others identify the user") },
+	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Sharing information that lets others identify the user") },
+	{ "social-location",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No sharing of physical location to other users") },
+	{ "social-location",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Sharing physical location to other users") },
+
+	/* v1.1 */
+	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references to homosexuality") },
+	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Indirect references to homosexuality") },
+	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Kissing between people of the same gender") },
+	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic sexual behavior between people of the same gender") },
+	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references to prostitution") },
+	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Indirect references to prostitution") },
+	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Direct references to prostitution") },
+	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic depictions of the act of prostitution") },
+	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references to adultery") },
+	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Indirect references to adultery") },
+	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Direct references to adultery") },
+	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic depictions of the act of adultery") },
+	{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No sexualized characters") },
+	{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Scantily clad human characters") },
+	{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Overtly sexualized human characters") },
+	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references to desecration") },
+	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Depictions or references to historical desecration") },
+	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Depictions of modern-day human desecration") },
+	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic depictions of modern-day desecration") },
+	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No visible dead human remains") },
+	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Visible dead human remains") },
+	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Dead human remains that are exposed to the elements") },
+	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic depictions of desecration of human bodies") },
+	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	/* TRANSLATORS: content rating description */
+	_("No references to slavery") },
+	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	/* TRANSLATORS: content rating description */
+	_("Depictions or references to historical slavery") },
+	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	/* TRANSLATORS: content rating description */
+	_("Depictions of modern-day slavery") },
+	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	/* TRANSLATORS: content rating description */
+	_("Graphic depictions of modern-day slavery") },
+	{ NULL, 0, NULL } };
+	for (i = 0; tab[i].id != NULL; i++) {
+		if (g_strcmp0 (tab[i].id, id) == 0 && tab[i].value == value)
+			return tab[i].desc;
+	}
+	return NULL;
+}
+
+/* data obtained from https://en.wikipedia.org/wiki/Video_game_rating_system */
+const gchar *
+gs_utils_content_rating_age_to_str (GsContentRatingSystem system, guint age)
+{
+	if (system == GS_CONTENT_RATING_SYSTEM_INCAA) {
+		if (age >= 18)
+			return "+18";
+		if (age >= 13)
+			return "+13";
+		return "ATP";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_ACB) {
+		if (age >= 18)
+			return "R18+";
+		if (age >= 15)
+			return "MA15+";
+		return "PG";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_DJCTQ) {
+		if (age >= 18)
+			return "18";
+		if (age >= 16)
+			return "16";
+		if (age >= 14)
+			return "14";
+		if (age >= 12)
+			return "12";
+		if (age >= 10)
+			return "10";
+		return "L";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_GSRR) {
+		if (age >= 18)
+			return "限制";
+		if (age >= 15)
+			return "輔15";
+		if (age >= 12)
+			return "輔12";
+		if (age >= 6)
+			return "保護";
+		return "普通";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_PEGI) {
+		if (age >= 18)
+			return "18";
+		if (age >= 16)
+			return "16";
+		if (age >= 12)
+			return "12";
+		if (age >= 7)
+			return "7";
+		if (age >= 3)
+			return "3";
+		return NULL;
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_KAVI) {
+		if (age >= 18)
+			return "18+";
+		if (age >= 16)
+			return "16+";
+		if (age >= 12)
+			return "12+";
+		if (age >= 7)
+			return "7+";
+		if (age >= 3)
+			return "3+";
+		return NULL;
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_USK) {
+		if (age >= 18)
+			return "18";
+		if (age >= 16)
+			return "16";
+		if (age >= 12)
+			return "12";
+		if (age >= 6)
+			return "6";
+		return "0";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_ESRA) {
+		if (age >= 25)
+			return "+25";
+		if (age >= 18)
+			return "+18";
+		if (age >= 12)
+			return "+12";
+		if (age >= 7)
+			return "+7";
+		if (age >= 3)
+			return "+3";
+		return NULL;
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_CERO) {
+		if (age >= 18)
+			return "Z";
+		if (age >= 17)
+			return "D";
+		if (age >= 15)
+			return "C";
+		if (age >= 12)
+			return "B";
+		return "A";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_OFLCNZ) {
+		if (age >= 18)
+			return "R18";
+		if (age >= 16)
+			return "R16";
+		if (age >= 15)
+			return "R15";
+		if (age >= 13)
+			return "R13";
+		return "G";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_RUSSIA) {
+		if (age >= 18)
+			return "18+";
+		if (age >= 16)
+			return "16+";
+		if (age >= 12)
+			return "12+";
+		if (age >= 6)
+			return "6+";
+		return "0+";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_MDA) {
+		if (age >= 18)
+			return "M18";
+		if (age >= 16)
+			return "ADV";
+		return "General";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_GRAC) {
+		if (age >= 18)
+			return "18";
+		if (age >= 15)
+			return "15";
+		if (age >= 12)
+			return "12";
+		return "ALL";
+	}
+	if (system == GS_CONTENT_RATING_SYSTEM_ESRB) {
+		if (age >= 18)
+			return "Adults Only";
+		if (age >= 17)
+			return "Mature";
+		if (age >= 13)
+			return "Teen";
+		if (age >= 10)
+			return "Everyone 10+";
+		if (age >= 6)
+			return "Everyone";
+		return "Early Childhood";
+	}
+	/* IARC = everything else */
+	if (age >= 18)
+		return "18+";
+	if (age >= 16)
+		return "16+";
+	if (age >= 12)
+		return "12+";
+	if (age >= 7)
+		return "7+";
+	if (age >= 3)
+		return "3+";
+	return NULL;
+}
+
+/* data obtained from https://en.wikipedia.org/wiki/Video_game_rating_system */
+GsContentRatingSystem
+gs_utils_content_rating_system_from_locale (const gchar *locale)
+{
+	g_auto(GStrv) split = g_strsplit (locale, "_", -1);
+
+	/* Argentina */
+	if (g_strcmp0 (split[0], "ar") == 0)
+		return GS_CONTENT_RATING_SYSTEM_INCAA;
+
+	/* Australia */
+	if (g_strcmp0 (split[0], "au") == 0)
+		return GS_CONTENT_RATING_SYSTEM_ACB;
+
+	/* Brazil */
+	if (g_strcmp0 (locale, "pt_BR") == 0)
+		return GS_CONTENT_RATING_SYSTEM_DJCTQ;
+
+	/* Taiwan */
+	if (g_strcmp0 (locale, "zh_TW") == 0)
+		return GS_CONTENT_RATING_SYSTEM_GSRR;
+
+	/* Europe (but not Finland or Germany), India, Israel,
+	 * Pakistan, Quebec, South Africa */
+	if (g_strcmp0 (locale, "en_GB") == 0 ||
+	    g_strcmp0 (split[0], "gb") == 0 ||
+	    g_strcmp0 (split[0], "al") == 0 ||
+	    g_strcmp0 (split[0], "ad") == 0 ||
+	    g_strcmp0 (split[0], "am") == 0 ||
+	    g_strcmp0 (split[0], "at") == 0 ||
+	    g_strcmp0 (split[0], "az") == 0 ||
+	    g_strcmp0 (split[0], "by") == 0 ||
+	    g_strcmp0 (split[0], "be") == 0 ||
+	    g_strcmp0 (split[0], "ba") == 0 ||
+	    g_strcmp0 (split[0], "bg") == 0 ||
+	    g_strcmp0 (split[0], "hr") == 0 ||
+	    g_strcmp0 (split[0], "cy") == 0 ||
+	    g_strcmp0 (split[0], "cz") == 0 ||
+	    g_strcmp0 (split[0], "dk") == 0 ||
+	    g_strcmp0 (split[0], "ee") == 0 ||
+	    g_strcmp0 (split[0], "fr") == 0 ||
+	    g_strcmp0 (split[0], "ge") == 0 ||
+	    g_strcmp0 (split[0], "gr") == 0 ||
+	    g_strcmp0 (split[0], "hu") == 0 ||
+	    g_strcmp0 (split[0], "is") == 0 ||
+	    g_strcmp0 (split[0], "it") == 0 ||
+	    g_strcmp0 (split[0], "kz") == 0 ||
+	    g_strcmp0 (split[0], "xk") == 0 ||
+	    g_strcmp0 (split[0], "lv") == 0 ||
+	    g_strcmp0 (split[0], "fl") == 0 ||
+	    g_strcmp0 (split[0], "lu") == 0 ||
+	    g_strcmp0 (split[0], "lt") == 0 ||
+	    g_strcmp0 (split[0], "mk") == 0 ||
+	    g_strcmp0 (split[0], "mt") == 0 ||
+	    g_strcmp0 (split[0], "md") == 0 ||
+	    g_strcmp0 (split[0], "mc") == 0 ||
+	    g_strcmp0 (split[0], "me") == 0 ||
+	    g_strcmp0 (split[0], "nl") == 0 ||
+	    g_strcmp0 (split[0], "no") == 0 ||
+	    g_strcmp0 (split[0], "pl") == 0 ||
+	    g_strcmp0 (split[0], "pt") == 0 ||
+	    g_strcmp0 (split[0], "ro") == 0 ||
+	    g_strcmp0 (split[0], "sm") == 0 ||
+	    g_strcmp0 (split[0], "rs") == 0 ||
+	    g_strcmp0 (split[0], "sk") == 0 ||
+	    g_strcmp0 (split[0], "si") == 0 ||
+	    g_strcmp0 (split[0], "es") == 0 ||
+	    g_strcmp0 (split[0], "se") == 0 ||
+	    g_strcmp0 (split[0], "ch") == 0 ||
+	    g_strcmp0 (split[0], "tr") == 0 ||
+	    g_strcmp0 (split[0], "ua") == 0 ||
+	    g_strcmp0 (split[0], "va") == 0 ||
+	    g_strcmp0 (split[0], "in") == 0 ||
+	    g_strcmp0 (split[0], "il") == 0 ||
+	    g_strcmp0 (split[0], "pk") == 0 ||
+	    g_strcmp0 (split[0], "za") == 0)
+		return GS_CONTENT_RATING_SYSTEM_PEGI;
+
+	/* Finland */
+	if (g_strcmp0 (split[0], "fi") == 0)
+		return GS_CONTENT_RATING_SYSTEM_KAVI;
+
+	/* Germany */
+	if (g_strcmp0 (split[0], "de") == 0)
+		return GS_CONTENT_RATING_SYSTEM_USK;
+
+	/* Iran */
+	if (g_strcmp0 (split[0], "ir") == 0)
+		return GS_CONTENT_RATING_SYSTEM_ESRA;
+
+	/* Japan */
+	if (g_strcmp0 (split[0], "jp") == 0)
+		return GS_CONTENT_RATING_SYSTEM_CERO;
+
+	/* New Zealand */
+	if (g_strcmp0 (split[0], "nz") == 0)
+		return GS_CONTENT_RATING_SYSTEM_OFLCNZ;
+
+	/* Russia: Content rating law */
+	if (g_strcmp0 (split[0], "ru") == 0)
+		return GS_CONTENT_RATING_SYSTEM_RUSSIA;
+
+	/* Singapore */
+	if (g_strcmp0 (split[0], "sg") == 0)
+		return GS_CONTENT_RATING_SYSTEM_MDA;
+
+	/* South Korea */
+	if (g_strcmp0 (split[0], "kr") == 0)
+		return GS_CONTENT_RATING_SYSTEM_GRAC;
+
+	/* USA, Canada, Mexico */
+	if (g_strcmp0 (locale, "en_US") == 0 ||
+	    g_strcmp0 (split[0], "us") == 0 ||
+	    g_strcmp0 (split[0], "ca") == 0 ||
+	    g_strcmp0 (split[0], "mx") == 0)
+		return GS_CONTENT_RATING_SYSTEM_ESRB;
+
+	/* everything else is IARC */
+	return GS_CONTENT_RATING_SYSTEM_IARC;
+}
+
+static const gchar *content_rating_strings[GS_CONTENT_RATING_SYSTEM_LAST][7] = {
+	{ "3+", "7+", "12+", "16+", "18+", NULL }, /* GS_CONTENT_RATING_SYSTEM_UNKNOWN */
+	{ "ATP", "+13", "+18", NULL }, /* GS_CONTENT_RATING_SYSTEM_INCAA */
+	{ "PG", "MA15+", "R18+", NULL }, /* GS_CONTENT_RATING_SYSTEM_ACB */
+	{ "L", "10", "12", "14", "16", "18", NULL }, /* GS_CONTENT_RATING_SYSTEM_DJCTQ */
+	{ "普通", "保護", "輔12", "輔15", "限制", NULL }, /* GS_CONTENT_RATING_SYSTEM_GSRR */
+	{ "3", "7", "12", "16", "18", NULL }, /* GS_CONTENT_RATING_SYSTEM_PEGI */
+	{ "3+", "7+", "12+", "16+", "18+", NULL }, /* GS_CONTENT_RATING_SYSTEM_KAVI */
+	{ "0", "6", "12", "16", "18", NULL}, /* GS_CONTENT_RATING_SYSTEM_USK */
+	{ "+3", "+7", "+12", "+18", "+25", NULL }, /* GS_CONTENT_RATING_SYSTEM_ESRA */
+	{ "A", "B", "C", "D", "Z", NULL }, /* GS_CONTENT_RATING_SYSTEM_CERO */
+	{ "G", "R13", "R15", "R16", "R18", NULL }, /* GS_CONTENT_RATING_SYSTEM_OFLCNZ */
+	{ "0+", "6+", "12+", "16+", "18+", NULL }, /* GS_CONTENT_RATING_SYSTEM_RUSSIA */
+	{ "General", "ADV", "M18", NULL }, /* GS_CONTENT_RATING_SYSTEM_MDA */
+	{ "ALL", "12", "15", "18", NULL }, /* GS_CONTENT_RATING_SYSTEM_GRAC */
+	{ "Early Childhood", "Everyone", "Everyone 10+", "Teen", "Mature", "Adults Only", NULL }, /* GS_CONTENT_RATING_SYSTEM_ESRB */
+	{ "3+", "7+", "12+", "16+", "18+", NULL }, /* GS_CONTENT_RATING_SYSTEM_IARC */
+};
+
+const gchar * const *
+gs_utils_content_rating_get_values (GsContentRatingSystem system)
+{
+	g_assert (system < GS_CONTENT_RATING_SYSTEM_LAST);
+	return content_rating_strings[system];
+}
+
+static guint content_rating_ages[GS_CONTENT_RATING_SYSTEM_LAST][7] = {
+	{ 3, 7, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_UNKNOWN */
+	{ 0, 13, 18 }, /* GS_CONTENT_RATING_SYSTEM_INCAA */
+	{ 0, 15, 18 }, /* GS_CONTENT_RATING_SYSTEM_ACB */
+	{ 0, 10, 12, 14, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_DJCTQ */
+	{ 0, 6, 12, 15, 18 }, /* GS_CONTENT_RATING_SYSTEM_GSRR */
+	{ 3, 7, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_PEGI */
+	{ 3, 7, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_KAVI */
+	{ 0, 6, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_USK */
+	{ 3, 7, 12, 18, 25 }, /* GS_CONTENT_RATING_SYSTEM_ESRA */
+	{ 0, 12, 15, 17, 18 }, /* GS_CONTENT_RATING_SYSTEM_CERO */
+	{ 0, 13, 15, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_OFLCNZ */
+	{ 0, 6, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_RUSSIA */
+	{ 0, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_MDA */
+	{ 0, 12, 15, 18 }, /* GS_CONTENT_RATING_SYSTEM_GRAC */
+	{ 0, 6, 10, 13, 17, 18 }, /* GS_CONTENT_RATING_SYSTEM_ESRB */
+	{ 3, 7, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_IARC */
+};
+
+const guint *
+gs_utils_content_rating_get_ages (GsContentRatingSystem system)
+{
+	g_assert (system < GS_CONTENT_RATING_SYSTEM_LAST);
+	return content_rating_ages[system];
+}
+
+const struct {
+	const gchar		*id;
+	EpcAppFilterOarsValue	 value;
+	guint			 csm_age;
+} id_to_csm_age[] =  {
+/* v1.0 */
+{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MILD,		3 },
+{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	4 },
+{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	6 },
+{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MILD,		3 },
+{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	7 },
+{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	8 },
+{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MILD,		4 },
+{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	9 },
+{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	14 },
+{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MILD,		9 },
+{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	11 },
+{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MILD,		11 },
+{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MILD,		10 },
+{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MILD,		13 },
+{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MILD,		8  },
+{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	11 },
+{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	14 },
+{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MILD,		3  },
+{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	8  },
+{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	14 },
+{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_NONE,	0  },
+{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MILD,	9  },
+{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MODERATE,10 },
+{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_INTENSE,	11 },
+{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_MILD,		7  },
+{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	8  },
+{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	10 },
+{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MILD,		7  },
+{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MILD,		4  },
+{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	13 },
+{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	12 },
+{ "social-info",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-info",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	13 },
+{ "social-location",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-location",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	13 },
+/* v1.1 additions */
+{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MILD,		0  },
+{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MILD,		10 },
+{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MILD,		8  },
+{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MILD,		13 },
+{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	15 },
+{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_NONE,	0  },
+{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MILD,	13 },
+{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MODERATE,	15 },
+{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MILD,		13 },
+{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	15 },
+{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ NULL, 0, 0 } };
+
+/**
+ * as_content_rating_id_value_to_csm_age:
+ * @id: the subsection ID e.g. "violence-cartoon"
+ * @value: the #AsContentRatingValue, e.g. %EPC_APP_FILTER_OARS_VALUE_INTENSE
+ *
+ * Gets the Common Sense Media approved age for a specific rating level.
+ *
+ * Returns: The age in years, or 0 for no details.
+ *
+ * Since: 0.5.12
+ **/
+guint
+as_content_rating_id_value_to_csm_age (const gchar *id, EpcAppFilterOarsValue value)
+{
+	guint i;
+	for (i = 0; id_to_csm_age[i].id != NULL; i++) {
+		if (value == id_to_csm_age[i].value &&
+		    g_strcmp0 (id, id_to_csm_age[i].id) == 0)
+			return id_to_csm_age[i].csm_age;
+	}
+	return 0;
+}
+
+/**
+ * as_content_rating_id_csm_age_to_value:
+ * @id: the subsection ID e.g. "violence-cartoon"
+ * @age: the age
+ *
+ * Gets the #EpcAppFilterOarsValue for a given age.
+ *
+ * Returns: the #EpcAppFilterOarsValue
+ **/
+EpcAppFilterOarsValue
+as_content_rating_id_csm_age_to_value (const gchar *id, guint age)
+{
+	EpcAppFilterOarsValue value;
+	guint i;
+
+	value = EPC_APP_FILTER_OARS_VALUE_UNKNOWN;
+
+	for (i = 0; id_to_csm_age[i].id != NULL; i++) {
+		if (age >= id_to_csm_age[i].csm_age &&
+		    g_strcmp0 (id, id_to_csm_age[i].id) == 0)
+			value = MAX (value, id_to_csm_age[i].value);
+	}
+	return value;
+}

--- a/panels/user-accounts/gs-content-rating.h
+++ b/panels/user-accounts/gs-content-rating.h
@@ -1,0 +1,61 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2015-2016 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+G_BEGIN_DECLS
+
+#include <glib-object.h>
+#include <libeos-parental-controls/app-filter.h>
+
+typedef enum {
+	GS_CONTENT_RATING_SYSTEM_UNKNOWN,
+	GS_CONTENT_RATING_SYSTEM_INCAA,
+	GS_CONTENT_RATING_SYSTEM_ACB,
+	GS_CONTENT_RATING_SYSTEM_DJCTQ,
+	GS_CONTENT_RATING_SYSTEM_GSRR,
+	GS_CONTENT_RATING_SYSTEM_PEGI,
+	GS_CONTENT_RATING_SYSTEM_KAVI,
+	GS_CONTENT_RATING_SYSTEM_USK,
+	GS_CONTENT_RATING_SYSTEM_ESRA,
+	GS_CONTENT_RATING_SYSTEM_CERO,
+	GS_CONTENT_RATING_SYSTEM_OFLCNZ,
+	GS_CONTENT_RATING_SYSTEM_RUSSIA,
+	GS_CONTENT_RATING_SYSTEM_MDA,
+	GS_CONTENT_RATING_SYSTEM_GRAC,
+	GS_CONTENT_RATING_SYSTEM_ESRB,
+	GS_CONTENT_RATING_SYSTEM_IARC,
+	/*< private >*/
+	GS_CONTENT_RATING_SYSTEM_LAST
+} GsContentRatingSystem;
+
+const gchar *gs_utils_content_rating_age_to_str (GsContentRatingSystem system,
+						 guint age);
+GsContentRatingSystem gs_utils_content_rating_system_from_locale (const gchar *locale);
+const gchar *gs_content_rating_key_value_to_str (const gchar *id,
+						 EpcAppFilterOarsValue value);
+const gchar *gs_content_rating_system_to_str (GsContentRatingSystem system);
+const gchar * const *gs_utils_content_rating_get_values (GsContentRatingSystem system);
+const guint *gs_utils_content_rating_get_ages (GsContentRatingSystem system);
+guint as_content_rating_id_value_to_csm_age (const gchar *id, EpcAppFilterOarsValue value);
+EpcAppFilterOarsValue as_content_rating_id_csm_age_to_value (const gchar *id, guint age);
+
+G_END_DECLS

--- a/panels/user-accounts/um-app-permissions.c
+++ b/panels/user-accounts/um-app-permissions.c
@@ -1,0 +1,802 @@
+/* um-app-permissions.c
+ *
+ * Copyright 2018 Endless, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <libeos-parental-controls/app-filter.h>
+#include <flatpak.h>
+#include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
+#include <strings.h>
+
+#include "gs-content-rating.h"
+
+#include "um-app-permissions.h"
+
+struct _UmAppPermissions
+{
+  GtkGrid     parent_instance;
+
+  GMenu      *age_menu;
+  GtkSwitch  *allow_system_installation_switch;
+  GtkSwitch  *allow_user_installation_switch;
+  GtkListBox *listbox;
+  GtkButton  *restriction_button;
+  GtkPopover *restriction_popover;
+
+  FlatpakInstallation *system_installation; /* (owned) */
+  FlatpakInstallation *user_installation; /* (owned) */
+
+  GSimpleActionGroup *action_group; /* (owned) */
+
+  ActUser    *user; /* (owned) */
+
+  GHashTable *blacklisted_apps; /* (owned) */
+  GListStore *apps; /* (owned) */
+
+  GCancellable *cancellable; /* (owned) */
+  EpcAppFilter *filter; /* (owned) */
+  guint         selected_age;
+
+  guint         blacklist_apps_source_id;
+};
+
+static gboolean blacklist_apps_cb (gpointer data);
+
+static gint compare_app_info_cb (gconstpointer a,
+                                 gconstpointer b,
+                                 gpointer      user_data);
+
+static void on_allow_installation_switch_active_changed_cb (GtkSwitch        *s,
+                                                            GParamSpec       *pspec,
+                                                            UmAppPermissions *self);
+
+static void on_set_age_action_activated (GSimpleAction *action,
+                                         GVariant      *param,
+                                         gpointer       user_data);
+
+G_DEFINE_TYPE (UmAppPermissions, um_app_permissions, GTK_TYPE_GRID)
+
+enum
+{
+  PROP_USER = 1,
+  N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+static const GActionEntry actions[] = {
+  { "set-age", on_set_age_action_activated, "u" }
+};
+
+/* FIXME: Factor this out and rely on code from libappstream-glib or gnome-software
+ * to do it. See: https://phabricator.endlessm.com/T24986 */
+static const gchar * const oars_categories[] =
+{
+  "violence-cartoon",
+  "violence-fantasy",
+  "violence-realistic",
+  "violence-bloodshed",
+  "violence-sexual",
+  "violence-desecration",
+  "violence-slavery",
+  "violence-worship",
+  "drugs-alcohol",
+  "drugs-narcotics",
+  "drugs-tobacco",
+  "sex-nudity",
+  "sex-themes",
+  "sex-homosexuality",
+  "sex-prostitution",
+  "sex-adultery",
+  "sex-appearance",
+  "language-profanity",
+  "language-humor",
+  "language-discrimination",
+  "social-chat",
+  "social-info",
+  "social-audio",
+  "social-location",
+  "social-contacts",
+  "money-purchasing",
+  "money-gambling",
+  NULL
+};
+
+/* Auxiliary methods */
+
+static void
+reload_apps (UmAppPermissions *self)
+{
+  GList *iter, *apps;
+
+  apps = g_app_info_get_all ();
+
+  g_list_store_remove_all (self->apps);
+
+  for (iter = apps; iter; iter = iter->next)
+    {
+      GAppInfo *app;
+      const gchar *app_name;
+
+      app = iter->data;
+      app_name = g_app_info_get_name (app);
+
+      if (!G_IS_DESKTOP_APP_INFO (app) ||
+          !g_app_info_should_show (app) ||
+          app_name[0] == '\0' ||
+          /* Endless' link apps have the "eos-link" prefix, and should be ignored too */
+          g_str_has_prefix (g_app_info_get_id (app), "eos-link"))
+        {
+          continue;
+        }
+
+      g_debug ("Processing app '%s' (%s)", g_app_info_get_id (app), g_app_info_get_executable (app));
+
+      g_list_store_insert_sorted (self->apps,
+                                  app,
+                                  compare_app_info_cb,
+                                  self);
+    }
+
+  g_list_free_full (apps, g_object_unref);
+}
+
+static GsContentRatingSystem
+get_content_rating_system (ActUser *user)
+{
+  const gchar *suffixes[] = {
+    ".UTF-8",
+    ".utf8",
+    "@",
+    NULL,
+  };
+  const gchar *user_language;
+  gchar *str;
+  gsize i;
+
+  user_language = act_user_get_language (user);
+
+  /* Remove the encoding suffixes */
+  for (i = 0; suffixes[i] != NULL; i++)
+    {
+      str = g_strstr_len (user_language, -1, suffixes[i]);
+      if (str != NULL)
+        *str = '\0';
+    }
+
+  return gs_utils_content_rating_system_from_locale (user_language);
+}
+
+static void
+schedule_update_blacklisted_apps (UmAppPermissions *self)
+{
+  if (self->blacklist_apps_source_id > 0)
+    return;
+
+  /* Use a timeout to batch multiple quick changes into a single
+   * update. 1 second is an arbitrary sufficiently small number */
+  self->blacklist_apps_source_id = g_timeout_add_seconds (1, blacklist_apps_cb, self);
+}
+
+static void
+update_app_filter (UmAppPermissions *self)
+{
+  g_autoptr(GError) error = NULL;
+
+  /* FIXME: make it asynchronous */
+  g_clear_pointer (&self->filter, epc_app_filter_unref);
+  self->filter = epc_get_app_filter (NULL,
+                                     act_user_get_uid (self->user),
+                                     FALSE,
+                                     self->cancellable,
+                                     &error);
+
+  if (error)
+    {
+      g_warning ("Error retrieving app filter for user '%s': %s",
+                  act_user_get_user_name (self->user),
+                  error->message);
+      return;
+    }
+
+  g_debug ("Retrieved new app filter for user '%s'", act_user_get_user_name (self->user));
+}
+
+static void
+update_categories_from_language (UmAppPermissions *self)
+{
+  GsContentRatingSystem rating_system;
+  const gchar * const * entries;
+  const gchar *rating_system_str;
+  const guint *ages;
+  gsize i;
+
+  rating_system = get_content_rating_system (self->user);
+  rating_system_str = gs_content_rating_system_to_str (rating_system);
+
+  g_debug ("Using rating system %s", rating_system_str);
+
+  entries = gs_utils_content_rating_get_values (rating_system);
+  ages = gs_utils_content_rating_get_ages (rating_system);
+
+  /* Fill in the age menu */
+  g_menu_remove_all (self->age_menu);
+
+  for (i = 0; entries[i] != NULL; i++)
+    {
+      g_autofree gchar *action = g_strdup_printf ("permissions.set-age(uint32 %u)", ages[i]);
+
+      g_menu_append (self->age_menu, entries[i], action);
+    }
+}
+
+/* Returns a human-readable but untranslated string, not suitable
+ * to be shown in any UI */
+static const gchar*
+oars_value_to_string (EpcAppFilterOarsValue oars_value)
+{
+  switch (oars_value)
+    {
+    case EPC_APP_FILTER_OARS_VALUE_UNKNOWN:
+      return "unknown";
+    case EPC_APP_FILTER_OARS_VALUE_NONE:
+      return "none";
+    case EPC_APP_FILTER_OARS_VALUE_MILD:
+      return "mild";
+    case EPC_APP_FILTER_OARS_VALUE_MODERATE:
+      return "moderate";
+    case EPC_APP_FILTER_OARS_VALUE_INTENSE:
+      return "intense";
+    }
+  return "";
+}
+
+static void
+update_oars_level (UmAppPermissions *self)
+{
+  GsContentRatingSystem rating_system;
+  const gchar *rating_age_category;
+  guint maximum_age;
+  gsize i;
+
+  g_assert (self->filter != NULL);
+
+  maximum_age = 0;
+
+  for (i = 0; oars_categories[i] != NULL; i++)
+    {
+      EpcAppFilterOarsValue oars_value;
+      guint age;
+
+      oars_value = epc_app_filter_get_oars_value (self->filter, oars_categories[i]);
+      age = as_content_rating_id_value_to_csm_age (oars_categories[i], oars_value);
+
+      g_debug ("OARS value for '%s': %s", oars_categories[i], oars_value_to_string (oars_value));
+
+      if (age > maximum_age)
+        maximum_age = age;
+    }
+
+  g_debug ("Effective age for this user: %u", maximum_age);
+
+  rating_system = get_content_rating_system (self->user);
+  rating_age_category = gs_utils_content_rating_age_to_str (rating_system, maximum_age);
+
+  gtk_button_set_label (self->restriction_button, rating_age_category);
+}
+
+static void
+update_allow_app_installation (UmAppPermissions *self)
+{
+  gboolean allow_system_installation;
+  gboolean allow_user_installation;
+
+  allow_system_installation = epc_app_filter_is_system_installation_allowed (self->filter);
+  allow_user_installation = epc_app_filter_is_user_installation_allowed (self->filter);
+
+  g_signal_handlers_block_by_func (self->allow_system_installation_switch,
+                                   on_allow_installation_switch_active_changed_cb,
+                                   self);
+
+  g_signal_handlers_block_by_func (self->allow_user_installation_switch,
+                                   on_allow_installation_switch_active_changed_cb,
+                                   self);
+
+  gtk_switch_set_active (self->allow_system_installation_switch, allow_system_installation);
+  gtk_switch_set_active (self->allow_user_installation_switch, allow_user_installation);
+
+  g_debug ("Allow system installation: %s", allow_system_installation ? "yes" : "no");
+  g_debug ("Allow user installation: %s", allow_user_installation ? "yes" : "no");
+
+  g_signal_handlers_unblock_by_func (self->allow_system_installation_switch,
+                                     on_allow_installation_switch_active_changed_cb,
+                                     self);
+
+  g_signal_handlers_unblock_by_func (self->allow_user_installation_switch,
+                                     on_allow_installation_switch_active_changed_cb,
+                                     self);
+}
+
+static void
+setup_parental_control_settings (UmAppPermissions *self)
+{
+  gtk_widget_set_visible (GTK_WIDGET (self), self->filter != NULL);
+
+  if (!self->filter)
+    return;
+
+  g_hash_table_remove_all (self->blacklisted_apps);
+
+  update_oars_level (self);
+  update_categories_from_language (self);
+  update_allow_app_installation (self);
+  reload_apps (self);
+}
+
+static gchar*
+get_flatpak_ref_for_app_id (UmAppPermissions *self,
+                            const gchar      *flatpak_id)
+{
+  g_autoptr(FlatpakInstalledRef) ref = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_assert (self->system_installation != NULL);
+  g_assert (self->user_installation != NULL);
+
+  ref = flatpak_installation_get_current_installed_app (self->user_installation,
+                                                        flatpak_id,
+                                                        self->cancellable,
+                                                        &error);
+
+  if (error)
+    {
+      if (!g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED))
+        g_warning ("Error searching for Flatpak ref: %s", error->message);
+      return NULL;
+    }
+
+  if (!ref || !flatpak_installed_ref_get_is_current (ref))
+    {
+      ref = flatpak_installation_get_current_installed_app (self->system_installation,
+                                                            flatpak_id,
+                                                            self->cancellable,
+                                                            &error);
+      if (error)
+        {
+          if (!g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED))
+            g_warning ("Error searching for Flatpak ref: %s", error->message);
+          return NULL;
+        }
+    }
+
+  return flatpak_ref_format_ref (FLATPAK_REF (ref));
+}
+
+/* Callbacks */
+
+static gboolean
+blacklist_apps_cb (gpointer data)
+{
+  g_auto(EpcAppFilterBuilder) builder = EPC_APP_FILTER_BUILDER_INIT ();
+  g_autoptr(EpcAppFilter) new_filter = NULL;
+  g_autoptr(GError) error = NULL;
+  UmAppPermissions *self = data;
+  GDesktopAppInfo *app;
+  GHashTableIter iter;
+  gboolean allow_system_installation;
+  gboolean allow_user_installation;
+  gsize i;
+
+  self->blacklist_apps_source_id = 0;
+
+  g_debug ("Building parental controls settings…");
+
+  /* Blacklist */
+
+  g_debug ("\t → Blacklisting apps");
+
+  g_hash_table_iter_init (&iter, self->blacklisted_apps);
+  while (g_hash_table_iter_next (&iter, (gpointer) &app, NULL))
+    {
+      g_autofree gchar *flatpak_id = NULL;
+
+      flatpak_id = g_desktop_app_info_get_string (app, "X-Flatpak");
+
+      if (flatpak_id)
+        {
+          g_autofree gchar *flatpak_ref = get_flatpak_ref_for_app_id (self, flatpak_id);
+
+          g_debug ("\t\t → Blacklisting Flatpak ref: %s", flatpak_ref);
+          epc_app_filter_builder_blacklist_flatpak_ref (&builder, flatpak_ref);
+        }
+      else
+        {
+          const gchar *executable = g_app_info_get_executable (G_APP_INFO (app));
+          g_autofree gchar *path = g_find_program_in_path (executable);
+
+          g_debug ("\t\t → Blacklisting path: %s", path);
+          epc_app_filter_builder_blacklist_path (&builder, path);
+        }
+    }
+
+  /* Maturity level */
+
+  g_debug ("\t → Maturity level");
+
+  for (i = 0; oars_categories[i] != NULL; i++)
+    {
+      EpcAppFilterOarsValue oars_value;
+      const gchar *oars_category;
+
+      oars_category = oars_categories[i];
+      oars_value = as_content_rating_id_csm_age_to_value (oars_category, self->selected_age);
+
+      g_debug ("\t\t → %s: %s", oars_category, oars_value_to_string (oars_value));
+
+      epc_app_filter_builder_set_oars_value (&builder, oars_category, oars_value);
+    }
+
+  /* App Installation */
+  allow_system_installation = gtk_switch_get_active (self->allow_system_installation_switch);
+  allow_user_installation = gtk_switch_get_active (self->allow_user_installation_switch);
+
+  g_debug ("\t → %s system installation", allow_system_installation ? "Enabling" : "Disabling");
+  g_debug ("\t → %s user installation", allow_user_installation ? "Enabling" : "Disabling");
+
+  epc_app_filter_builder_set_allow_user_installation (&builder, allow_user_installation);
+  epc_app_filter_builder_set_allow_system_installation (&builder, allow_system_installation);
+
+  new_filter = epc_app_filter_builder_end (&builder);
+
+  /* FIXME: should become asynchronous */
+  epc_set_app_filter (NULL,
+                      act_user_get_uid (self->user),
+                      new_filter,
+                      TRUE,
+                      self->cancellable,
+                      &error);
+
+  if (error)
+    {
+      g_warning ("Error updating app filter: %s", error->message);
+      setup_parental_control_settings (self);
+    }
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+on_allow_installation_switch_active_changed_cb (GtkSwitch        *s,
+                                                GParamSpec       *pspec,
+                                                UmAppPermissions *self)
+{
+  schedule_update_blacklisted_apps (self);
+}
+
+static void
+on_switch_active_changed_cb (GtkSwitch        *s,
+                             GParamSpec       *pspec,
+                             UmAppPermissions *self)
+{
+  GAppInfo *app;
+  gboolean allowed;
+
+  app = g_object_get_data (G_OBJECT (s), "GAppInfo");
+  allowed = gtk_switch_get_active (s);
+
+  if (allowed)
+    {
+      gboolean removed;
+
+      g_debug ("Removing '%s' from blacklisted apps", g_app_info_get_id (app));
+
+      removed = g_hash_table_remove (self->blacklisted_apps, app);
+      g_assert (removed);
+    }
+  else
+    {
+      gboolean added;
+
+      g_debug ("Blacklisting '%s'", g_app_info_get_id (app));
+
+      added = g_hash_table_add (self->blacklisted_apps, g_object_ref (app));
+      g_assert (added);
+    }
+
+  schedule_update_blacklisted_apps (self);
+}
+
+static GtkWidget *
+create_row_for_app_cb (gpointer item,
+                       gpointer user_data)
+{
+  g_autoptr(GIcon) icon = NULL;
+  UmAppPermissions *self;
+  GtkWidget *box, *w;
+  GAppInfo *app;
+  gboolean allowed;
+  const gchar *app_name;
+  gint size;
+
+  self = UM_APP_PERMISSIONS (user_data);
+  app = item;
+  app_name = g_app_info_get_name (app);
+
+  g_assert (G_IS_DESKTOP_APP_INFO (app));
+
+  icon = g_app_info_get_icon (app);
+  if (icon == NULL)
+    icon = g_themed_icon_new ("application-x-executable");
+  else
+    g_object_ref (icon);
+
+  box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
+  gtk_container_set_border_width (GTK_CONTAINER (box), 12);
+  gtk_widget_set_margin_end (box, 12);
+
+  /* Icon */
+  w = gtk_image_new_from_gicon (icon, GTK_ICON_SIZE_DIALOG);
+  gtk_icon_size_lookup (GTK_ICON_SIZE_DND, &size, NULL);
+  gtk_image_set_pixel_size (GTK_IMAGE (w), size);
+  gtk_container_add (GTK_CONTAINER (box), w);
+
+  /* App name label */
+  w = g_object_new (GTK_TYPE_LABEL,
+                    "label", app_name,
+                    "hexpand", TRUE,
+                    "xalign", 0.0,
+                    NULL);
+  gtk_container_add (GTK_CONTAINER (box), w);
+
+  /* Switch */
+  w = gtk_switch_new ();
+  gtk_container_add (GTK_CONTAINER (box), w);
+
+  gtk_widget_show_all (box);
+
+  /* Fetch status from AccountService */
+  allowed = epc_app_filter_is_appinfo_allowed (self->filter, app);
+
+  gtk_switch_set_active (GTK_SWITCH (w), allowed);
+  g_object_set_data_full (G_OBJECT (w), "GAppInfo", g_object_ref (app), g_object_unref);
+
+  if (allowed)
+    g_hash_table_remove (self->blacklisted_apps, app);
+  else if (!allowed)
+    g_hash_table_add (self->blacklisted_apps, g_object_ref (app));
+
+  g_signal_connect (w, "notify::active", G_CALLBACK (on_switch_active_changed_cb), self);
+
+  return box;
+}
+
+static gint
+compare_app_info_cb (gconstpointer a,
+                     gconstpointer b,
+                     gpointer      user_data)
+{
+  GAppInfo *app_a = (GAppInfo*) a;
+  GAppInfo *app_b = (GAppInfo*) b;
+
+  return g_utf8_collate (g_app_info_get_display_name (app_a),
+                         g_app_info_get_display_name (app_b));
+}
+
+static void
+on_set_age_action_activated (GSimpleAction *action,
+                             GVariant      *param,
+                             gpointer       user_data)
+{
+  GsContentRatingSystem rating_system;
+  UmAppPermissions *self;
+  const gchar * const * entries;
+  const guint *ages;
+  guint age;
+  guint i;
+
+  self = UM_APP_PERMISSIONS (user_data);
+  age = g_variant_get_uint32 (param);
+
+  rating_system = get_content_rating_system (self->user);
+  entries = gs_utils_content_rating_get_values (rating_system);
+  ages = gs_utils_content_rating_get_ages (rating_system);
+
+  /* Update the button */
+  for (i = 0; entries[i] != NULL; i++)
+    {
+      if (ages[i] == age)
+        {
+          gtk_button_set_label (self->restriction_button, entries[i]);
+          break;
+        }
+    }
+
+  g_assert (entries[i] != NULL);
+
+  g_debug ("Selected age: %u", age);
+
+  self->selected_age = age;
+
+  schedule_update_blacklisted_apps (self);
+}
+
+/* GObject overrides */
+
+static void
+um_app_permissions_finalize (GObject *object)
+{
+  UmAppPermissions *self = (UmAppPermissions *)object;
+
+  g_assert (self->blacklist_apps_source_id == 0);
+
+  g_cancellable_cancel (self->cancellable);
+  g_clear_object (&self->action_group);
+  g_clear_object (&self->apps);
+  g_clear_object (&self->cancellable);
+  g_clear_object (&self->system_installation);
+  g_clear_object (&self->user);
+  g_clear_object (&self->user_installation);
+
+  g_clear_pointer (&self->blacklisted_apps, g_hash_table_unref);
+  g_clear_pointer (&self->filter, epc_app_filter_unref);
+
+  G_OBJECT_CLASS (um_app_permissions_parent_class)->finalize (object);
+}
+
+
+static void
+um_app_permissions_dispose (GObject *object)
+{
+  UmAppPermissions *self = (UmAppPermissions *)object;
+
+  if (self->blacklist_apps_source_id > 0)
+    {
+      blacklist_apps_cb (self);
+      g_source_remove (self->blacklist_apps_source_id);
+      self->blacklist_apps_source_id = 0;
+    }
+
+  G_OBJECT_CLASS (um_app_permissions_parent_class)->dispose (object);
+}
+
+static void
+um_app_permissions_get_property (GObject    *object,
+                                 guint       prop_id,
+                                 GValue     *value,
+                                 GParamSpec *pspec)
+{
+  UmAppPermissions *self = UM_APP_PERMISSIONS (object);
+
+  switch (prop_id)
+    {
+    case PROP_USER:
+      g_value_set_object (value, self->user);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+um_app_permissions_set_property (GObject      *object,
+                                 guint         prop_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
+{
+  UmAppPermissions *self = UM_APP_PERMISSIONS (object);
+
+  switch (prop_id)
+    {
+    case PROP_USER:
+      um_app_permissions_set_user (self, g_value_get_object (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+um_app_permissions_class_init (UmAppPermissionsClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->finalize = um_app_permissions_finalize;
+  object_class->dispose = um_app_permissions_dispose;
+  object_class->get_property = um_app_permissions_get_property;
+  object_class->set_property = um_app_permissions_set_property;
+
+  properties[PROP_USER] = g_param_spec_object ("user",
+                                               "User",
+                                               "User",
+                                               ACT_TYPE_USER,
+                                               G_PARAM_READWRITE |
+                                               G_PARAM_STATIC_STRINGS |
+                                               G_PARAM_EXPLICIT_NOTIFY);
+
+  g_object_class_install_properties (object_class, N_PROPS, properties);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/user-accounts/app-permissions.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, UmAppPermissions, age_menu);
+  gtk_widget_class_bind_template_child (widget_class, UmAppPermissions, allow_system_installation_switch);
+  gtk_widget_class_bind_template_child (widget_class, UmAppPermissions, allow_user_installation_switch);
+  gtk_widget_class_bind_template_child (widget_class, UmAppPermissions, restriction_button);
+  gtk_widget_class_bind_template_child (widget_class, UmAppPermissions, restriction_popover);
+  gtk_widget_class_bind_template_child (widget_class, UmAppPermissions, listbox);
+
+  gtk_widget_class_bind_template_callback (widget_class, on_allow_installation_switch_active_changed_cb);
+}
+
+static void
+um_app_permissions_init (UmAppPermissions *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+
+  self->system_installation = flatpak_installation_new_system (NULL, NULL);
+  self->user_installation = flatpak_installation_new_user (NULL, NULL);
+
+  self->action_group = g_simple_action_group_new ();
+  g_action_map_add_action_entries (G_ACTION_MAP (self->action_group),
+                                   actions,
+                                   G_N_ELEMENTS (actions),
+                                   self);
+
+  gtk_widget_insert_action_group (GTK_WIDGET (self),
+                                  "permissions",
+                                  G_ACTION_GROUP (self->action_group));
+
+  gtk_popover_bind_model (self->restriction_popover, G_MENU_MODEL (self->age_menu), NULL);
+  self->blacklisted_apps = g_hash_table_new_full (g_direct_hash, g_direct_equal, g_object_unref, NULL);
+
+  self->cancellable = g_cancellable_new ();
+  self->apps = g_list_store_new (G_TYPE_APP_INFO);
+
+  gtk_list_box_bind_model (self->listbox,
+                           G_LIST_MODEL (self->apps),
+                           create_row_for_app_cb,
+                           self,
+                           NULL);
+}
+
+ActUser*
+um_app_permissions_get_user (UmAppPermissions *self)
+{
+  g_return_val_if_fail (UM_IS_APP_PERMISSIONS (self), NULL);
+
+  return self->user;
+}
+
+void
+um_app_permissions_set_user (UmAppPermissions *self,
+                             ActUser          *user)
+{
+  g_return_if_fail (UM_IS_APP_PERMISSIONS (self));
+  g_return_if_fail (ACT_IS_USER (user));
+
+  if (g_set_object (&self->user, user))
+    {
+      update_app_filter (self);
+      setup_parental_control_settings (self);
+
+      g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_USER]);
+    }
+}

--- a/panels/user-accounts/um-app-permissions.h
+++ b/panels/user-accounts/um-app-permissions.h
@@ -1,0 +1,37 @@
+/* um-app-permissions.h
+ *
+ * Copyright 2018 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <act/act.h>
+#include <gtk/gtk.h>
+#include <shell/cc-panel.h>
+
+G_BEGIN_DECLS
+
+#define UM_TYPE_APP_PERMISSIONS (um_app_permissions_get_type())
+
+G_DECLARE_FINAL_TYPE (UmAppPermissions, um_app_permissions, UM, APP_PERMISSIONS, GtkGrid)
+
+ActUser* um_app_permissions_get_user (UmAppPermissions *self);
+void     um_app_permissions_set_user (UmAppPermissions *self,
+                                      ActUser          *user);
+
+G_END_DECLS

--- a/panels/user-accounts/um-user-panel.c
+++ b/panels/user-accounts/um-user-panel.c
@@ -42,6 +42,7 @@
 #include "um-cell-renderer-user-image.h"
 
 #include "um-account-dialog.h"
+#include "um-app-permissions.h"
 #include "cc-language-chooser.h"
 #include "um-password-dialog.h"
 #include "um-carousel.h"
@@ -70,6 +71,7 @@ struct _CcUserPanelPrivate {
         GtkWidget *notification;
         GSettings *login_screen_settings;
 
+        UmAppPermissions *app_permissions;
         GtkWidget *headerbar_buttons;
         GtkWidget *main_box;
         UmCarousel *carousel;
@@ -911,6 +913,8 @@ show_user (ActUser *user, CcUserPanelPrivate *d)
 
         if (d->permission != NULL)
                 on_permission_changed (d->permission, NULL, d);
+
+        um_app_permissions_set_user (d->app_permissions, user);
 }
 
 static void
@@ -1335,6 +1339,8 @@ setup_main_window (CcUserPanel *self)
         d->carousel = UM_CAROUSEL (get_widget (d, "carousel"));
         g_signal_connect (d->carousel, "item-activated", G_CALLBACK (set_selected_user), d);
 
+        d->app_permissions = UM_APP_PERMISSIONS (get_widget (d, "app-permissions"));
+
         button = get_widget (d, "add-user-toolbutton");
         g_signal_connect (button, "clicked", G_CALLBACK (add_user), d);
 
@@ -1554,4 +1560,6 @@ cc_user_panel_class_init (CcUserPanelClass *klass)
         panel_class->get_help_uri = cc_user_panel_get_help_uri;
 
         g_type_class_add_private (klass, sizeof (CcUserPanelPrivate));
+
+        g_type_ensure (UM_TYPE_APP_PERMISSIONS);
 }

--- a/panels/user-accounts/user-accounts.gresource.xml
+++ b/panels/user-accounts/user-accounts.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/org/gnome/control-center/user-accounts">
     <file alias="account-dialog.ui" preprocess="xml-stripblanks">data/account-dialog.ui</file>
+    <file alias="app-permissions.ui" preprocess="xml-stripblanks">data/app-permissions.ui</file>
     <file alias="join-dialog.ui" preprocess="xml-stripblanks">data/join-dialog.ui</file>
     <file alias="account-fingerprint.ui" preprocess="xml-stripblanks">data/account-fingerprint.ui</file>
     <file alias="password-dialog.ui" preprocess="xml-stripblanks">data/password-dialog.ui</file>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -202,10 +202,12 @@ panels/updates/gnome-updates-panel.desktop.in.in
 [type: gettext/glade]panels/user-accounts/data/account-dialog.ui
 [type: gettext/glade]panels/user-accounts/data/account-fingerprint.ui
 panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in
+[type: gettext/glade]panels/user-accounts/data/app-permissions.ui
 [type: gettext/glade]panels/user-accounts/data/history-dialog.ui
 [type: gettext/glade]panels/user-accounts/data/join-dialog.ui
 [type: gettext/glade]panels/user-accounts/data/password-dialog.ui
 [type: gettext/glade]panels/user-accounts/data/user-accounts-dialog.ui
+panels/user-accounts/gs-content-rating.c
 panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in
 panels/user-accounts/pw-utils.c
 panels/user-accounts/run-passwd.c


### PR DESCRIPTION
Trivial cherry-pick of https://github.com/endlessm/gnome-control-center/pull/141 (https://phabricator.endlessm.com/T23897) to eos3.5 to see what Jenkins makes of it, since it’s not currently building on master due to the Debian rebase.