### PR TITLE
T23897 Mostly fix age mappings with parental controls

### DIFF
--- a/panels/user-accounts/gs-content-rating.c
+++ b/panels/user-accounts/gs-content-rating.c
@@ -22,6 +22,7 @@
 #include "config.h"
 
 #include <glib/gi18n.h>
+#include <string.h>
 
 #include "gs-content-rating.h"
 
@@ -539,121 +540,206 @@ gs_utils_content_rating_age_to_str (GsContentRatingSystem system, guint age)
 	return NULL;
 }
 
+/*
+ * parse_locale:
+ * @locale: (transfer full): a locale to parse
+ * @language_out: (out) (optional) (nullable): return location for the parsed
+ *    language, or %NULL to ignore
+ * @territory_out: (out) (optional) (nullable): return location for the parsed
+ *    territory, or %NULL to ignore
+ * @codeset_out: (out) (optional) (nullable): return location for the parsed
+ *    codeset, or %NULL to ignore
+ * @modifier_out: (out) (optional) (nullable): return location for the parsed
+ *    modifier, or %NULL to ignore
+ *
+ * Parse @locale as a locale string of the form
+ * `language[_territory][.codeset][@modifier]` — see `man 3 setlocale` for
+ * details.
+ *
+ * On success, %TRUE will be returned, and the components of the locale will be
+ * returned in the given addresses, with each component not including any
+ * separators. Otherwise, %FALSE will be returned and the components will be set
+ * to %NULL.
+ *
+ * @locale is modified, and any returned non-%NULL pointers will point inside
+ * it.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
+static gboolean
+parse_locale (gchar *locale  /* (transfer full) */,
+	      const gchar **language_out,
+	      const gchar **territory_out,
+	      const gchar **codeset_out,
+	      const gchar **modifier_out)
+{
+	gchar *separator;
+	const gchar *language = NULL, *territory = NULL, *codeset = NULL, *modifier = NULL;
+
+	separator = strrchr (locale, '@');
+	if (separator != NULL) {
+		modifier = separator + 1;
+		*separator = '\0';
+	}
+
+	separator = strrchr (locale, '.');
+	if (separator != NULL) {
+		codeset = separator + 1;
+		*separator = '\0';
+	}
+
+	separator = strrchr (locale, '_');
+	if (separator != NULL) {
+		territory = separator + 1;
+		*separator = '\0';
+	}
+
+	language = locale;
+
+	/* Parse failure? */
+	if (*language == '\0') {
+		language = NULL;
+		territory = NULL;
+		codeset = NULL;
+		modifier = NULL;
+	}
+
+	if (language_out != NULL)
+		*language_out = language;
+	if (territory_out != NULL)
+		*territory_out = territory;
+	if (codeset_out != NULL)
+		*codeset_out = codeset;
+	if (modifier_out != NULL)
+		*modifier_out = modifier;
+
+	return (language != NULL);
+}
+
 /* data obtained from https://en.wikipedia.org/wiki/Video_game_rating_system */
 GsContentRatingSystem
 gs_utils_content_rating_system_from_locale (const gchar *locale)
 {
-	g_auto(GStrv) split = g_strsplit (locale, "_", -1);
+	g_autofree gchar *locale_copy = g_strdup (locale);
+	const gchar *language, *territory;
+
+	/* Default to IARC for locales which can’t be parsed. */
+	if (!parse_locale (locale_copy, &language, &territory, NULL, NULL))
+		return GS_CONTENT_RATING_SYSTEM_IARC;
 
 	/* Argentina */
-	if (g_strcmp0 (split[0], "ar") == 0)
+	if (g_strcmp0 (language, "ar") == 0)
 		return GS_CONTENT_RATING_SYSTEM_INCAA;
 
 	/* Australia */
-	if (g_strcmp0 (split[0], "au") == 0)
+	if (g_strcmp0 (language, "au") == 0)
 		return GS_CONTENT_RATING_SYSTEM_ACB;
 
 	/* Brazil */
-	if (g_strcmp0 (locale, "pt_BR") == 0)
+	if (g_strcmp0 (language, "pt") == 0 &&
+	    g_strcmp0 (territory, "BR") == 0)
 		return GS_CONTENT_RATING_SYSTEM_DJCTQ;
 
 	/* Taiwan */
-	if (g_strcmp0 (locale, "zh_TW") == 0)
+	if (g_strcmp0 (language, "zh") == 0 &&
+	    g_strcmp0 (territory, "TW") == 0)
 		return GS_CONTENT_RATING_SYSTEM_GSRR;
 
 	/* Europe (but not Finland or Germany), India, Israel,
 	 * Pakistan, Quebec, South Africa */
-	if (g_strcmp0 (locale, "en_GB") == 0 ||
-	    g_strcmp0 (split[0], "gb") == 0 ||
-	    g_strcmp0 (split[0], "al") == 0 ||
-	    g_strcmp0 (split[0], "ad") == 0 ||
-	    g_strcmp0 (split[0], "am") == 0 ||
-	    g_strcmp0 (split[0], "at") == 0 ||
-	    g_strcmp0 (split[0], "az") == 0 ||
-	    g_strcmp0 (split[0], "by") == 0 ||
-	    g_strcmp0 (split[0], "be") == 0 ||
-	    g_strcmp0 (split[0], "ba") == 0 ||
-	    g_strcmp0 (split[0], "bg") == 0 ||
-	    g_strcmp0 (split[0], "hr") == 0 ||
-	    g_strcmp0 (split[0], "cy") == 0 ||
-	    g_strcmp0 (split[0], "cz") == 0 ||
-	    g_strcmp0 (split[0], "dk") == 0 ||
-	    g_strcmp0 (split[0], "ee") == 0 ||
-	    g_strcmp0 (split[0], "fr") == 0 ||
-	    g_strcmp0 (split[0], "ge") == 0 ||
-	    g_strcmp0 (split[0], "gr") == 0 ||
-	    g_strcmp0 (split[0], "hu") == 0 ||
-	    g_strcmp0 (split[0], "is") == 0 ||
-	    g_strcmp0 (split[0], "it") == 0 ||
-	    g_strcmp0 (split[0], "kz") == 0 ||
-	    g_strcmp0 (split[0], "xk") == 0 ||
-	    g_strcmp0 (split[0], "lv") == 0 ||
-	    g_strcmp0 (split[0], "fl") == 0 ||
-	    g_strcmp0 (split[0], "lu") == 0 ||
-	    g_strcmp0 (split[0], "lt") == 0 ||
-	    g_strcmp0 (split[0], "mk") == 0 ||
-	    g_strcmp0 (split[0], "mt") == 0 ||
-	    g_strcmp0 (split[0], "md") == 0 ||
-	    g_strcmp0 (split[0], "mc") == 0 ||
-	    g_strcmp0 (split[0], "me") == 0 ||
-	    g_strcmp0 (split[0], "nl") == 0 ||
-	    g_strcmp0 (split[0], "no") == 0 ||
-	    g_strcmp0 (split[0], "pl") == 0 ||
-	    g_strcmp0 (split[0], "pt") == 0 ||
-	    g_strcmp0 (split[0], "ro") == 0 ||
-	    g_strcmp0 (split[0], "sm") == 0 ||
-	    g_strcmp0 (split[0], "rs") == 0 ||
-	    g_strcmp0 (split[0], "sk") == 0 ||
-	    g_strcmp0 (split[0], "si") == 0 ||
-	    g_strcmp0 (split[0], "es") == 0 ||
-	    g_strcmp0 (split[0], "se") == 0 ||
-	    g_strcmp0 (split[0], "ch") == 0 ||
-	    g_strcmp0 (split[0], "tr") == 0 ||
-	    g_strcmp0 (split[0], "ua") == 0 ||
-	    g_strcmp0 (split[0], "va") == 0 ||
-	    g_strcmp0 (split[0], "in") == 0 ||
-	    g_strcmp0 (split[0], "il") == 0 ||
-	    g_strcmp0 (split[0], "pk") == 0 ||
-	    g_strcmp0 (split[0], "za") == 0)
+	if ((g_strcmp0 (language, "en") == 0 &&
+	     g_strcmp0 (territory, "GB") == 0) ||
+	    g_strcmp0 (language, "gb") == 0 ||
+	    g_strcmp0 (language, "al") == 0 ||
+	    g_strcmp0 (language, "ad") == 0 ||
+	    g_strcmp0 (language, "am") == 0 ||
+	    g_strcmp0 (language, "at") == 0 ||
+	    g_strcmp0 (language, "az") == 0 ||
+	    g_strcmp0 (language, "by") == 0 ||
+	    g_strcmp0 (language, "be") == 0 ||
+	    g_strcmp0 (language, "ba") == 0 ||
+	    g_strcmp0 (language, "bg") == 0 ||
+	    g_strcmp0 (language, "hr") == 0 ||
+	    g_strcmp0 (language, "cy") == 0 ||
+	    g_strcmp0 (language, "cz") == 0 ||
+	    g_strcmp0 (language, "dk") == 0 ||
+	    g_strcmp0 (language, "ee") == 0 ||
+	    g_strcmp0 (language, "fr") == 0 ||
+	    g_strcmp0 (language, "ge") == 0 ||
+	    g_strcmp0 (language, "gr") == 0 ||
+	    g_strcmp0 (language, "hu") == 0 ||
+	    g_strcmp0 (language, "is") == 0 ||
+	    g_strcmp0 (language, "it") == 0 ||
+	    g_strcmp0 (language, "kz") == 0 ||
+	    g_strcmp0 (language, "xk") == 0 ||
+	    g_strcmp0 (language, "lv") == 0 ||
+	    g_strcmp0 (language, "fl") == 0 ||
+	    g_strcmp0 (language, "lu") == 0 ||
+	    g_strcmp0 (language, "lt") == 0 ||
+	    g_strcmp0 (language, "mk") == 0 ||
+	    g_strcmp0 (language, "mt") == 0 ||
+	    g_strcmp0 (language, "md") == 0 ||
+	    g_strcmp0 (language, "mc") == 0 ||
+	    g_strcmp0 (language, "me") == 0 ||
+	    g_strcmp0 (language, "nl") == 0 ||
+	    g_strcmp0 (language, "no") == 0 ||
+	    g_strcmp0 (language, "pl") == 0 ||
+	    g_strcmp0 (language, "pt") == 0 ||
+	    g_strcmp0 (language, "ro") == 0 ||
+	    g_strcmp0 (language, "sm") == 0 ||
+	    g_strcmp0 (language, "rs") == 0 ||
+	    g_strcmp0 (language, "sk") == 0 ||
+	    g_strcmp0 (language, "si") == 0 ||
+	    g_strcmp0 (language, "es") == 0 ||
+	    g_strcmp0 (language, "se") == 0 ||
+	    g_strcmp0 (language, "ch") == 0 ||
+	    g_strcmp0 (language, "tr") == 0 ||
+	    g_strcmp0 (language, "ua") == 0 ||
+	    g_strcmp0 (language, "va") == 0 ||
+	    g_strcmp0 (language, "in") == 0 ||
+	    g_strcmp0 (language, "il") == 0 ||
+	    g_strcmp0 (language, "pk") == 0 ||
+	    g_strcmp0 (language, "za") == 0)
 		return GS_CONTENT_RATING_SYSTEM_PEGI;
 
 	/* Finland */
-	if (g_strcmp0 (split[0], "fi") == 0)
+	if (g_strcmp0 (language, "fi") == 0)
 		return GS_CONTENT_RATING_SYSTEM_KAVI;
 
 	/* Germany */
-	if (g_strcmp0 (split[0], "de") == 0)
+	if (g_strcmp0 (language, "de") == 0)
 		return GS_CONTENT_RATING_SYSTEM_USK;
 
 	/* Iran */
-	if (g_strcmp0 (split[0], "ir") == 0)
+	if (g_strcmp0 (language, "ir") == 0)
 		return GS_CONTENT_RATING_SYSTEM_ESRA;
 
 	/* Japan */
-	if (g_strcmp0 (split[0], "jp") == 0)
+	if (g_strcmp0 (language, "jp") == 0)
 		return GS_CONTENT_RATING_SYSTEM_CERO;
 
 	/* New Zealand */
-	if (g_strcmp0 (split[0], "nz") == 0)
+	if (g_strcmp0 (language, "nz") == 0)
 		return GS_CONTENT_RATING_SYSTEM_OFLCNZ;
 
 	/* Russia: Content rating law */
-	if (g_strcmp0 (split[0], "ru") == 0)
+	if (g_strcmp0 (language, "ru") == 0)
 		return GS_CONTENT_RATING_SYSTEM_RUSSIA;
 
 	/* Singapore */
-	if (g_strcmp0 (split[0], "sg") == 0)
+	if (g_strcmp0 (language, "sg") == 0)
 		return GS_CONTENT_RATING_SYSTEM_MDA;
 
 	/* South Korea */
-	if (g_strcmp0 (split[0], "kr") == 0)
+	if (g_strcmp0 (language, "kr") == 0)
 		return GS_CONTENT_RATING_SYSTEM_GRAC;
 
 	/* USA, Canada, Mexico */
-	if (g_strcmp0 (locale, "en_US") == 0 ||
-	    g_strcmp0 (split[0], "us") == 0 ||
-	    g_strcmp0 (split[0], "ca") == 0 ||
-	    g_strcmp0 (split[0], "mx") == 0)
+	if ((g_strcmp0 (language, "en") == 0 &&
+	     g_strcmp0 (territory, "US") == 0) ||
+	    g_strcmp0 (language, "us") == 0 ||
+	    g_strcmp0 (language, "ca") == 0 ||
+	    g_strcmp0 (language, "mx") == 0)
 		return GS_CONTENT_RATING_SYSTEM_ESRB;
 
 	/* everything else is IARC */

--- a/panels/user-accounts/gs-content-rating.c
+++ b/panels/user-accounts/gs-content-rating.c
@@ -473,11 +473,12 @@ gs_utils_content_rating_age_to_str (GsContentRatingSystem system, guint age)
 			return "6";
 		return "0";
 	}
+	/* Reference: http://www.esra.org.ir/ */
 	if (system == GS_CONTENT_RATING_SYSTEM_ESRA) {
-		if (age >= 25)
-			return "+25";
 		if (age >= 18)
 			return "+18";
+		if (age >= 15)
+			return "+15";
 		if (age >= 12)
 			return "+12";
 		if (age >= 7)
@@ -777,7 +778,7 @@ static const gchar *content_rating_strings[GS_CONTENT_RATING_SYSTEM_LAST][7] = {
 	{ "3", "7", "12", "16", "18", NULL }, /* GS_CONTENT_RATING_SYSTEM_PEGI */
 	{ "3+", "7+", "12+", "16+", "18+", NULL }, /* GS_CONTENT_RATING_SYSTEM_KAVI */
 	{ "0", "6", "12", "16", "18", NULL}, /* GS_CONTENT_RATING_SYSTEM_USK */
-	{ "+3", "+7", "+12", "+18", "+25", NULL }, /* GS_CONTENT_RATING_SYSTEM_ESRA */
+	{ "+3", "+7", "+12", "+15", "+18", NULL }, /* GS_CONTENT_RATING_SYSTEM_ESRA */
 	{ "A", "B", "C", "D", "Z", NULL }, /* GS_CONTENT_RATING_SYSTEM_CERO */
 	{ "G", "R13", "R15", "R16", "R18", NULL }, /* GS_CONTENT_RATING_SYSTEM_OFLCNZ */
 	{ "0+", "6+", "12+", "16+", "18+", NULL }, /* GS_CONTENT_RATING_SYSTEM_RUSSIA */
@@ -803,7 +804,7 @@ static guint content_rating_ages[GS_CONTENT_RATING_SYSTEM_LAST][7] = {
 	{ 3, 7, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_PEGI */
 	{ 3, 7, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_KAVI */
 	{ 0, 6, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_USK */
-	{ 3, 7, 12, 18, 25 }, /* GS_CONTENT_RATING_SYSTEM_ESRA */
+	{ 3, 7, 12, 15, 18 }, /* GS_CONTENT_RATING_SYSTEM_ESRA */
 	{ 0, 12, 15, 17, 18 }, /* GS_CONTENT_RATING_SYSTEM_CERO */
 	{ 0, 13, 15, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_OFLCNZ */
 	{ 0, 6, 12, 16, 18 }, /* GS_CONTENT_RATING_SYSTEM_RUSSIA */

--- a/panels/user-accounts/gs-content-rating.c
+++ b/panels/user-accounts/gs-content-rating.c
@@ -376,6 +376,28 @@ gs_content_rating_key_value_to_str (const gchar *id, EpcAppFilterOarsValue value
 const gchar *
 gs_utils_content_rating_age_to_str (GsContentRatingSystem system, guint age)
 {
+	/* Apply some fixups for specific rating systems. This is needed to
+	 * ensure that we can do a round trip from
+	 * @system → CSM → OARS → CSM → @system reversibly. The underlying issue
+	 * is that the appstream-glib OARS ↔ CSM mapping does not use CSM ages
+	 * 1–2, 5, 16–17 or 18+. The lack of age 16 is most important, since a
+	 * lot of region-specific rating systems use that age. Without such a
+	 * mapping, any reverse transformation from OARS → CSM is going to
+	 * under-estimate the CSM age so the overall CSM → OARS → CSM
+	 * transformation becomes non-reversible. */
+	if (age == 15 &&
+	    (system == GS_CONTENT_RATING_SYSTEM_IARC ||
+	     system == GS_CONTENT_RATING_SYSTEM_UNKNOWN ||
+	     system == GS_CONTENT_RATING_SYSTEM_DJCTQ ||
+	     system == GS_CONTENT_RATING_SYSTEM_PEGI ||
+	     system == GS_CONTENT_RATING_SYSTEM_KAVI ||
+	     system == GS_CONTENT_RATING_SYSTEM_USK ||
+	     system == GS_CONTENT_RATING_SYSTEM_RUSSIA ||
+	     system == GS_CONTENT_RATING_SYSTEM_MDA))
+		age = 16;
+	else if (age == 15 && system == GS_CONTENT_RATING_SYSTEM_ESRB)
+		age = 17;
+
 	if (system == GS_CONTENT_RATING_SYSTEM_INCAA) {
 		if (age >= 18)
 			return "+18";

--- a/panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in
+++ b/panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in
@@ -15,7 +15,7 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.accounts.user-administration org.freedesktop.realmd.configure-realm org.freedesktop.realmd.login-policy</annotate>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.accounts.user-administration org.freedesktop.realmd.configure-realm org.freedesktop.realmd.login-policy com.endlessm.ParentalControls.AppFilter.ChangeOwn com.endlessm.ParentalControls.AppFilter.ChangeAny</annotate>
   </action>
 
 </policyconfig>

--- a/panels/user-accounts/um-app-permissions.c
+++ b/panels/user-accounts/um-app-permissions.c
@@ -344,10 +344,21 @@ update_allow_app_installation (UmAppPermissions *self)
 static void
 setup_parental_control_settings (UmAppPermissions *self)
 {
+  gboolean is_authorized;
+
   gtk_widget_set_visible (GTK_WIDGET (self), self->filter != NULL);
 
   if (!self->filter)
     return;
+
+  /* We only want to make the controls sensitive if we have permission to save
+   * changes (@is_authorized). */
+  if (self->permission != NULL)
+    is_authorized = g_permission_get_allowed (G_PERMISSION (self->permission));
+  else
+    is_authorized = TRUE;
+
+  gtk_widget_set_sensitive (GTK_WIDGET (self), is_authorized);
 
   g_hash_table_remove_all (self->blacklisted_apps);
 

--- a/panels/user-accounts/um-app-permissions.c
+++ b/panels/user-accounts/um-app-permissions.c
@@ -867,6 +867,10 @@ um_app_permissions_set_user (UmAppPermissions *self,
   g_return_if_fail (UM_IS_APP_PERMISSIONS (self));
   g_return_if_fail (ACT_IS_USER (user));
 
+  /* If we have pending unsaved changes from the previous user, force them to be
+   * saved first. */
+  flush_update_blacklisted_apps (self);
+
   if (g_set_object (&self->user, user))
     {
       update_app_filter (self);

--- a/panels/user-accounts/um-app-permissions.c
+++ b/panels/user-accounts/um-app-permissions.c
@@ -203,6 +203,17 @@ schedule_update_blacklisted_apps (UmAppPermissions *self)
 }
 
 static void
+flush_update_blacklisted_apps (UmAppPermissions *self)
+{
+  if (self->blacklist_apps_source_id > 0)
+    {
+      blacklist_apps_cb (self);
+      g_source_remove (self->blacklist_apps_source_id);
+      self->blacklist_apps_source_id = 0;
+    }
+}
+
+static void
 update_app_filter (UmAppPermissions *self)
 {
   g_autoptr(GError) error = NULL;
@@ -718,12 +729,7 @@ um_app_permissions_dispose (GObject *object)
 {
   UmAppPermissions *self = (UmAppPermissions *)object;
 
-  if (self->blacklist_apps_source_id > 0)
-    {
-      blacklist_apps_cb (self);
-      g_source_remove (self->blacklist_apps_source_id);
-      self->blacklist_apps_source_id = 0;
-    }
+  flush_update_blacklisted_apps (self);
 
   G_OBJECT_CLASS (um_app_permissions_parent_class)->dispose (object);
 }

--- a/panels/user-accounts/um-app-permissions.h
+++ b/panels/user-accounts/um-app-permissions.h
@@ -34,4 +34,8 @@ ActUser* um_app_permissions_get_user (UmAppPermissions *self);
 void     um_app_permissions_set_user (UmAppPermissions *self,
                                       ActUser          *user);
 
+GPermission *um_app_permissions_get_permission (UmAppPermissions *self);
+void         um_app_permissions_set_permission (UmAppPermissions *self,
+                                                GPermission      *permission);
+
 G_END_DECLS

--- a/panels/user-accounts/um-user-panel.c
+++ b/panels/user-accounts/um-user-panel.c
@@ -915,6 +915,7 @@ show_user (ActUser *user, CcUserPanelPrivate *d)
                 on_permission_changed (d->permission, NULL, d);
 
         um_app_permissions_set_user (d->app_permissions, user);
+        um_app_permissions_set_permission (d->app_permissions, d->permission);
 }
 
 static void


### PR DESCRIPTION
This is based on #150. Only the top two commits are relevant here.

We store parental controls age restrictions as a set of OARS categories, but the user interface in g-c-c presents a locale-specific set of ratings to the user. So we need a reversible mapping from locale-specific rating system → CSM → OARS → CSM → locale-specific rating system.

Unfortunately, mostly due to the fact that CSM doesn’t have OARS ↔ CSM mappings for age 16, that’s not possible for all ratings systems. In particular, IARC and PEGI had problems.

Fix that by adding some workarounds to the reverse mapping.

Also update the ESRA categories while we’re there, since they seem to have changed in the last 3 years. This fixes an issue with round-tripping their old ‘+25’ category (it no longer exists).

There are still issues with CERO rating D (gets mapped back to CERO C because there is no CSM age 17) and with OFLCNZ R16 (gets mapped back to R15 because there is no CSM age 16). These are not critical for the regions we care about most immediately. The long-term fix is to ensure that there are OARS ↔ CSM mappings for ages 16 and 17, but that requires discussion on the specification.

https://phabricator.endlessm.com/T23897