### PR TITLE
user-accounts: Don’t list non-flatpak apps in parental controls

### DIFF
--- a/panels/user-accounts/um-app-permissions.c
+++ b/panels/user-accounts/um-app-permissions.c
@@ -149,7 +149,11 @@ reload_apps (UmAppPermissions *self)
           !g_app_info_should_show (app) ||
           app_name[0] == '\0' ||
           /* Endless' link apps have the "eos-link" prefix, and should be ignored too */
-          g_str_has_prefix (g_app_info_get_id (app), "eos-link"))
+          g_str_has_prefix (g_app_info_get_id (app), "eos-link") ||
+          /* FIXME: Only list flatpak apps for now; we really need a system-wide MAC
+           * to be able to reliably support blacklisting system programs. See
+           * https://phabricator.endlessm.com/T25080. */
+          !g_desktop_app_info_has_key (G_DESKTOP_APP_INFO (app), "X-Flatpak"))
         {
           continue;
         }


### PR DESCRIPTION
Currently, we can’t really support blacklisting non-flatpak apps, as
they could be exec()ed from anywhere; flatpak apps typically need to be
run via `flatpak run`, which is easier to add blacklisting support to.

(It is possible to run a flatpak app with a manual bwrap invocation, but
that’s a lot harder.)

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24022