### PR TITLE
user-accounts: Allow ‘Remove User’ button to be focused

### DIFF
--- a/panels/user-accounts/data/user-accounts-dialog.ui
+++ b/panels/user-accounts/data/user-accounts-dialog.ui
@@ -441,7 +441,7 @@
             <child>
               <object class="GtkButton" id="remove-user-toolbutton">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
                 <property name="halign">GTK_ALIGN_END</property>
                 <property name="valign">GTK_ALIGN_END</property>
                 <property name="margin_bottom">20</property>


### PR DESCRIPTION
Otherwise it isn’t included in the tab focus cycle, and can’t be
navigated to with the tab key.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24990