### PR TITLE
updates: Add additional keywords to ‘Automatic Updates’ panel

### DIFF
--- a/panels/updates/gnome-updates-panel.desktop.in.in
+++ b/panels/updates/gnome-updates-panel.desktop.in.in
@@ -13,4 +13,4 @@ X-GNOME-Bugzilla-Product=gnome-control-center
 X-GNOME-Bugzilla-Component=updates
 X-GNOME-Bugzilla-Version=@VERSION@
 # Translators: those are keywords for the automatic updates control-center panel
-_Keywords=Updates;Automatic;
+_Keywords=Updates;Automatic;Background;Metered;


### PR DESCRIPTION
So that it appears when searching for ‘background data’ or ‘background
updates’ or ‘metered data’.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

*Note*: This is a translatable string change. There’s no Phabricator issue for it, and no schedule driving its acceptance. It’s just a drive-by fix for something I noticed while working on https://phabricator.endlessm.com/T24117.