### PR TITLE
network: Add mnemonic for ‘Restrict background data usage’ checkbox

### DIFF
--- a/panels/network/connection-editor/details-page.ui
+++ b/panels/network/connection-editor/details-page.ui
@@ -373,8 +373,9 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Restrict background data usage</property>
+                <property name="label" translatable="yes">Restrict _background data usage</property>
                 <property name="hexpand">True</property>
+                <property name="use_underline">True</property>
               </object>
             </child>
 


### PR DESCRIPTION
The other checkboxes on this page all have mnemonics. It seems unfair
for the background data usage one to be left out of the party.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

*Note*: This is a translatable string change. There’s no Phabricator issue for it, and no schedule driving its acceptance. It’s just a drive-by fix for something I noticed while working on https://phabricator.endlessm.com/T24117.