### PR TITLE
user-accounts: Use ‘No Restriction’ rather than ‘Disabled’ for ages

### DIFF
--- a/panels/user-accounts/um-app-permissions.c
+++ b/panels/user-accounts/um-app-permissions.c
@@ -314,7 +314,7 @@ update_categories_from_language (UmAppPermissions *self)
   g_menu_remove_all (self->age_menu);
 
   disabled_action = g_strdup_printf ("permissions.set-age(uint32 %u)", oars_disabled_age);
-  g_menu_append (self->age_menu, _("Disabled"), disabled_action);
+  g_menu_append (self->age_menu, _("No Restriction"), disabled_action);
 
   for (i = 0; entries[i] != NULL; i++)
     {
@@ -386,7 +386,7 @@ update_oars_level (UmAppPermissions *self)
 
   /* Unrestricted? */
   if (rating_age_category == NULL || all_categories_unset)
-    rating_age_category = _("Disabled");
+    rating_age_category = _("No Restriction");
 
   gtk_button_set_label (self->restriction_button, rating_age_category);
 }
@@ -767,7 +767,7 @@ on_set_age_action_activated (GSimpleAction *action,
 
   /* Update the button */
   if (age == oars_disabled_age)
-    gtk_button_set_label (self->restriction_button, _("Disabled"));
+    gtk_button_set_label (self->restriction_button, _("No Restriction"));
 
   for (i = 0; age != oars_disabled_age && entries[i] != NULL; i++)
     {


### PR DESCRIPTION
When disabling parental controls, the string ‘Disabled’ doesn’t fit well
in the UI, since the UI ends up reading “Show Apps Suitable For:
Disabled”, which sounds like it’s for disabled users, rather than that
the feature is disabled.

Use ‘No Restriction’ instead.

The string ‘Disabled’ was originally used to allow re-use of existing
translations.

Signed-off-by: Philip Withnall <withnall@endlessm.com>