### PR TITLE
background: Stop using a custom XDG dir for wallpapers

### DIFF
--- a/panels/background/Makefile.am
+++ b/panels/background/Makefile.am
@@ -94,11 +94,7 @@ desktopdir = $(datadir)/applications
 desktop_in_files = gnome-background-panel.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
-xdgdirsdir = $(datadir)/xdg-user-dirs
-xdgdirs_in_files = gnome-wallpapers.desktop.in
-xdgdirs_DATA = $(xdgdirs_in_files:.desktop.in=.desktop)
-
-CLEANFILES = $(desktop_in_files) $(desktop_DATA) $(xdgdirs_DATA) $(BUILT_SOURCES) stamp-gdesktop-enums-types.h
-EXTRA_DIST = $(resource_files) background.gresource.xml gnome-wallpapers.desktop.in
+CLEANFILES = $(desktop_in_files) $(desktop_DATA) $(BUILT_SOURCES) stamp-gdesktop-enums-types.h
+EXTRA_DIST = $(resource_files) background.gresource.xml
 
 -include $(top_srcdir)/git.mk

--- a/panels/background/bg-pictures-source.c
+++ b/panels/background/bg-pictures-source.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <cairo-gobject.h>
 #include <gio/gio.h>
+#include <glib.h>
+#include <glib/gi18n.h>
 #include <grilo.h>
 #include <libgnome-desktop/gnome-desktop-thumbnail.h>
 #include <gdesktop-enums.h>
@@ -1025,9 +1027,9 @@ bg_pictures_source_init (BgPicturesSource *self)
 
   priv->picture_dir_monitor = monitor_path (self, pictures_path);
 
-  wallpapers_path = g_get_user_special_dir_for_desktop_id ("gnome-wallpapers.desktop");
-  if (wallpapers_path)
-    priv->wallpapers_dir_monitor = monitor_path (self, wallpapers_path);
+  /* Nautilus puts wallpapers into this subdirectory: */
+  wallpapers_path = g_build_filename (pictures_path, _("Wallpapers"), NULL);
+  priv->wallpapers_dir_monitor = monitor_path (self, wallpapers_path);
 
   cache_path = bg_pictures_source_get_cache_path ();
   priv->cache_dir_monitor = monitor_path (self, cache_path);

--- a/panels/background/gnome-wallpapers.desktop.in
+++ b/panels/background/gnome-wallpapers.desktop.in
@@ -1,3 +1,0 @@
-[Directory]
-_Name=Wallpapers
-Parent=XDG_PICTURES_DIR

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,11 +3,11 @@
 [encoding: UTF-8]
 [type: gettext/glade]panels/background/background.ui
 panels/background/bg-colors-source.c
+panels/background/bg-pictures-source.c
 panels/background/cc-background-chooser-dialog.c
 panels/background/cc-background-item.c
 panels/background/cc-background-panel.c
 panels/background/gnome-background-panel.desktop.in.in
-panels/background/gnome-wallpapers.desktop.in
 [type: gettext/glade]panels/bluetooth/bluetooth.ui
 panels/bluetooth/cc-bluetooth-panel.c
 panels/bluetooth/gnome-bluetooth-panel.desktop.in.in


### PR DESCRIPTION
This is a partial revert of commit
84eca50c748fe982392bf9bad8084107061f8918. It drops
gnome-wallpapers.desktop as a way of specifying where g-c-c should look
for wallpapers, and instead hard-codes the directory to look in as a
subdirectory of XDG_PICTURES_DIR.

There are several reasons for this:
 • It was using a custom GLib API
   (g_get_user_special_dir_for_desktop_id()) which was not upstream and
   wasn’t going to be accepted upstreamed.
 • Looking at `man 5 user-dirs.dirs`, it says “the format of
   user-dirs.dirs is designed to allow direct sourcing of this file in
   shell scripts”, but if gnome-wallpapers.desktop were ever overridden
   in user-dirs.dirs, that would break, as `gnome-wallpapers.desktop` is
   not a valid sh variable name. So the default value could only ever be
   used.
 • Nautilus’ ‘Set as Wallpaper’ feature, which is what this was designed
   to complement, always copies images to
   ${XDG_PICTURES_DIR}/Wallpapers rather than using
   gnome-wallpapers.desktop. (The upstream version of Nautilus
   translates the ‘Wallpapers’ directory; the EOS 3.5 version does not.
   That will change.)

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T25445