### PR TITLE
debian: Drop xdg-user-dirs directory

### DIFF
--- a/debian/gnome-control-center-data.install
+++ b/debian/gnome-control-center-data.install
@@ -5,4 +5,3 @@ usr/share/gettext/its
 usr/share/icons
 usr/share/pixmaps/faces
 usr/share/polkit-1
-usr/share/xdg-user-dirs


### PR DESCRIPTION
We are no longer installing a custom xdg-user-dirs desktop file.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T25445