### PR TITLE
user-accounts: vertically centre per-app switches

### DIFF
--- a/panels/user-accounts/um-app-permissions.c
+++ b/panels/user-accounts/um-app-permissions.c
@@ -713,7 +713,9 @@ create_row_for_app_cb (gpointer item,
   gtk_container_add (GTK_CONTAINER (box), w);
 
   /* Switch */
-  w = gtk_switch_new ();
+  w = g_object_new (GTK_TYPE_SWITCH,
+                    "valign", GTK_ALIGN_CENTER,
+                    NULL);
   gtk_container_add (GTK_CONTAINER (box), w);
 
   gtk_widget_show_all (box);


### PR DESCRIPTION
The default for valign is GTK_ALIGN_FILL; this caused the switches to be stretched vertically, which may have looked fine for Old Adwaita but looks bad for New Adwaita. Since we are sticking with g-c-c 3.26 for eos 3.6.0, we need to fix this independently of the rebase.

Before: ![Screenshot from 2019-04-26 16-04-22](https://user-images.githubusercontent.com/86760/56818726-289bb700-6840-11e9-8979-3dc265f76b3b.png)

After: ![Screenshot from 2019-04-26 16-18-58](https://user-images.githubusercontent.com/86760/56818724-289bb700-6840-11e9-9eb5-7f1e34725c5b.png)


https://phabricator.endlessm.com/T25193