### PR TITLE
fixup! background: Remove GdkColor deprecation warnings

### DIFF
--- a/panels/background/cc-background-item.c
+++ b/panels/background/cc-background-item.c
@@ -999,7 +999,7 @@ colors_equal (const char *a,
 	GdkRGBA color1, color2;
 
 	gdk_rgba_parse (&color1, a);
-	gdk_rgba_parse (&color1, b);
+	gdk_rgba_parse (&color2, b);
 
 	return gdk_rgba_equal (&color1, &color2);
 }


### PR DESCRIPTION
Fixes a copy-paste error introduced in https://github.com/endlessm/gnome-control-center/pull/169

https://phabricator.endlessm.com/T26592