### PR TITLE
Fix double free when discovering search providers

### DIFF
--- a/panels/search/cc-search-panel.c
+++ b/panels/search/cc-search-panel.c
@@ -614,7 +614,7 @@ search_providers_discover_ready (GObject *source,
 
   for (l = discover_result->providers; l != NULL; l = l->next)
     {
-      g_autoptr(GFile) provider = l->data;
+      GFile *provider = l->data;
       search_panel_add_one_provider (self, provider);
     }
 


### PR DESCRIPTION
This fixes a crash when clicking on Search on latest master.

https://phabricator.endlessm.com/T25338