### PR TITLE
parental-controls: Migrate to malcontent

### DIFF
--- a/panels/search/meson.build
+++ b/panels/search/meson.build
@@ -28,7 +28,7 @@ resource_data = files(
 )
 
 deps = common_deps + [
-    dependency('eos-parental-controls-0')
+    dependency('malcontent-0', version: '>= 0.3.0')
   ]
 
 sources += gnome.compile_resources(

--- a/panels/user-accounts/cc-app-permissions.c
+++ b/panels/user-accounts/cc-app-permissions.c
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include <libeos-parental-controls/app-filter.h>
+#include <libmalcontent/malcontent.h>
 #include <flatpak.h>
 #include <gio/gio.h>
 #include <gio/gdesktopappinfo.h>
@@ -59,7 +59,8 @@ struct _CcAppPermissions
   GListStore *apps; /* (owned) */
 
   GCancellable *cancellable; /* (owned) */
-  EpcAppFilter *filter; /* (owned) */
+  MctManager   *manager; /* (owned) */
+  MctAppFilter *filter; /* (owned) */
   guint         selected_age; /* @oars_disabled_age to disable OARS */
 
   guint         blacklist_apps_source_id;
@@ -268,18 +269,18 @@ update_app_filter (CcAppPermissions *self)
 {
   g_autoptr(GError) error = NULL;
 
-  g_clear_pointer (&self->filter, epc_app_filter_unref);
+  g_clear_pointer (&self->filter, mct_app_filter_unref);
 
   /* We don’t care about the app filter for administrators. */
   if (act_user_get_account_type (self->user) == ACT_USER_ACCOUNT_TYPE_ADMINISTRATOR)
     return;
 
   /* FIXME: make it asynchronous */
-  self->filter = epc_get_app_filter (NULL,
-                                     act_user_get_uid (self->user),
-                                     FALSE,
-                                     self->cancellable,
-                                     &error);
+  self->filter = mct_manager_get_app_filter (self->manager,
+                                             act_user_get_uid (self->user),
+                                             MCT_GET_APP_FILTER_FLAGS_NONE,
+                                             self->cancellable,
+                                             &error);
 
   if (error)
     {
@@ -331,19 +332,19 @@ update_categories_from_language (CcAppPermissions *self)
 /* Returns a human-readable but untranslated string, not suitable
  * to be shown in any UI */
 static const gchar*
-oars_value_to_string (EpcAppFilterOarsValue oars_value)
+oars_value_to_string (MctAppFilterOarsValue oars_value)
 {
   switch (oars_value)
     {
-    case EPC_APP_FILTER_OARS_VALUE_UNKNOWN:
+    case MCT_APP_FILTER_OARS_VALUE_UNKNOWN:
       return "unknown";
-    case EPC_APP_FILTER_OARS_VALUE_NONE:
+    case MCT_APP_FILTER_OARS_VALUE_NONE:
       return "none";
-    case EPC_APP_FILTER_OARS_VALUE_MILD:
+    case MCT_APP_FILTER_OARS_VALUE_MILD:
       return "mild";
-    case EPC_APP_FILTER_OARS_VALUE_MODERATE:
+    case MCT_APP_FILTER_OARS_VALUE_MODERATE:
       return "moderate";
-    case EPC_APP_FILTER_OARS_VALUE_INTENSE:
+    case MCT_APP_FILTER_OARS_VALUE_INTENSE:
       return "intense";
     }
   return "";
@@ -365,11 +366,11 @@ update_oars_level (CcAppPermissions *self)
 
   for (i = 0; oars_categories[i] != NULL; i++)
     {
-      EpcAppFilterOarsValue oars_value;
+      MctAppFilterOarsValue oars_value;
       guint age;
 
-      oars_value = epc_app_filter_get_oars_value (self->filter, oars_categories[i]);
-      all_categories_unset &= (oars_value == EPC_APP_FILTER_OARS_VALUE_UNKNOWN);
+      oars_value = mct_app_filter_get_oars_value (self->filter, oars_categories[i]);
+      all_categories_unset &= (oars_value == MCT_APP_FILTER_OARS_VALUE_UNKNOWN);
       age = as_content_rating_id_value_to_csm_age (oars_categories[i], oars_value);
 
       g_debug ("OARS value for '%s': %s", oars_categories[i], oars_value_to_string (oars_value));
@@ -397,8 +398,8 @@ update_allow_app_installation (CcAppPermissions *self)
   gboolean allow_system_installation;
   gboolean allow_user_installation;
 
-  allow_system_installation = epc_app_filter_is_system_installation_allowed (self->filter);
-  allow_user_installation = epc_app_filter_is_user_installation_allowed (self->filter);
+  allow_system_installation = mct_app_filter_is_system_installation_allowed (self->filter);
+  allow_user_installation = mct_app_filter_is_user_installation_allowed (self->filter);
 
   /* While the underlying permissions storage allows the system and user settings
    * to be stored completely independently, force the system setting to OFF if
@@ -509,8 +510,8 @@ get_flatpak_ref_for_app_id (CcAppPermissions *self,
 static gboolean
 blacklist_apps_cb (gpointer data)
 {
-  g_auto(EpcAppFilterBuilder) builder = EPC_APP_FILTER_BUILDER_INIT ();
-  g_autoptr(EpcAppFilter) new_filter = NULL;
+  g_auto(MctAppFilterBuilder) builder = MCT_APP_FILTER_BUILDER_INIT ();
+  g_autoptr(MctAppFilter) new_filter = NULL;
   g_autoptr(GError) error = NULL;
   CcAppPermissions *self = data;
   GDesktopAppInfo *app;
@@ -547,7 +548,7 @@ blacklist_apps_cb (gpointer data)
             }
 
           g_debug ("\t\t → Blacklisting Flatpak ref: %s", flatpak_ref);
-          epc_app_filter_builder_blacklist_flatpak_ref (&builder, flatpak_ref);
+          mct_app_filter_builder_blacklist_flatpak_ref (&builder, flatpak_ref);
         }
       else
         {
@@ -561,7 +562,7 @@ blacklist_apps_cb (gpointer data)
             }
 
           g_debug ("\t\t → Blacklisting path: %s", path);
-          epc_app_filter_builder_blacklist_path (&builder, path);
+          mct_app_filter_builder_blacklist_path (&builder, path);
         }
     }
 
@@ -574,7 +575,7 @@ blacklist_apps_cb (gpointer data)
 
   for (i = 0; self->selected_age != oars_disabled_age && oars_categories[i] != NULL; i++)
     {
-      EpcAppFilterOarsValue oars_value;
+      MctAppFilterOarsValue oars_value;
       const gchar *oars_category;
 
       oars_category = oars_categories[i];
@@ -582,7 +583,7 @@ blacklist_apps_cb (gpointer data)
 
       g_debug ("\t\t → %s: %s", oars_category, oars_value_to_string (oars_value));
 
-      epc_app_filter_builder_set_oars_value (&builder, oars_category, oars_value);
+      mct_app_filter_builder_set_oars_value (&builder, oars_category, oars_value);
     }
 
   /* App Installation */
@@ -592,18 +593,18 @@ blacklist_apps_cb (gpointer data)
   g_debug ("\t → %s system installation", allow_system_installation ? "Enabling" : "Disabling");
   g_debug ("\t → %s user installation", allow_user_installation ? "Enabling" : "Disabling");
 
-  epc_app_filter_builder_set_allow_user_installation (&builder, allow_user_installation);
-  epc_app_filter_builder_set_allow_system_installation (&builder, allow_system_installation);
+  mct_app_filter_builder_set_allow_user_installation (&builder, allow_user_installation);
+  mct_app_filter_builder_set_allow_system_installation (&builder, allow_system_installation);
 
-  new_filter = epc_app_filter_builder_end (&builder);
+  new_filter = mct_app_filter_builder_end (&builder);
 
   /* FIXME: should become asynchronous */
-  epc_set_app_filter (NULL,
-                      act_user_get_uid (self->user),
-                      new_filter,
-                      TRUE,
-                      self->cancellable,
-                      &error);
+  mct_manager_set_app_filter (self->manager,
+                              act_user_get_uid (self->user),
+                              new_filter,
+                              MCT_GET_APP_FILTER_FLAGS_INTERACTIVE,
+                              self->cancellable,
+                              &error);
 
   if (error)
     {
@@ -721,7 +722,7 @@ create_row_for_app_cb (gpointer item,
   gtk_widget_show_all (box);
 
   /* Fetch status from AccountService */
-  allowed = epc_app_filter_is_appinfo_allowed (self->filter, app);
+  allowed = mct_app_filter_is_appinfo_allowed (self->filter, app);
 
   gtk_switch_set_active (GTK_SWITCH (w), allowed);
   g_object_set_data_full (G_OBJECT (w), "GAppInfo", g_object_ref (app), g_object_unref);
@@ -817,7 +818,8 @@ cc_app_permissions_finalize (GObject *object)
   g_clear_object (&self->permission);
 
   g_clear_pointer (&self->blacklisted_apps, g_hash_table_unref);
-  g_clear_pointer (&self->filter, epc_app_filter_unref);
+  g_clear_pointer (&self->filter, mct_app_filter_unref);
+  g_clear_object (&self->manager);
   g_clear_object (&self->app_info_monitor);
 
   G_OBJECT_CLASS (cc_app_permissions_parent_class)->finalize (object);
@@ -924,10 +926,25 @@ cc_app_permissions_class_init (CcAppPermissionsClass *klass)
 static void
 cc_app_permissions_init (CcAppPermissions *self)
 {
+  g_autoptr(GDBusConnection) system_bus = NULL;
+  g_autoptr(GError) error = NULL;
+
   gtk_widget_init_template (GTK_WIDGET (self));
 
   self->system_installation = flatpak_installation_new_system (NULL, NULL);
   self->user_installation = flatpak_installation_new_user (NULL, NULL);
+
+  self->cancellable = g_cancellable_new ();
+
+  /* FIXME: should become asynchronous */
+  system_bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, self->cancellable, &error);
+  if (system_bus == NULL)
+    {
+      g_warning ("Error getting system bus while setting up app permissions: %s", error->message);
+      return;
+    }
+
+  self->manager = mct_manager_new (system_bus);
 
   self->action_group = g_simple_action_group_new ();
   g_action_map_add_action_entries (G_ACTION_MAP (self->action_group),
@@ -942,7 +959,6 @@ cc_app_permissions_init (CcAppPermissions *self)
   gtk_popover_bind_model (self->restriction_popover, G_MENU_MODEL (self->age_menu), NULL);
   self->blacklisted_apps = g_hash_table_new_full (g_direct_hash, g_direct_equal, g_object_unref, NULL);
 
-  self->cancellable = g_cancellable_new ();
   self->apps = g_list_store_new (G_TYPE_APP_INFO);
 
   self->app_info_monitor = g_app_info_monitor_get ();

--- a/panels/user-accounts/gs-content-rating.c
+++ b/panels/user-accounts/gs-content-rating.c
@@ -63,305 +63,305 @@ gs_content_rating_system_to_str (GsContentRatingSystem system)
 }
 
 const gchar *
-gs_content_rating_key_value_to_str (const gchar *id, EpcAppFilterOarsValue value)
+gs_content_rating_key_value_to_str (const gchar *id, MctAppFilterOarsValue value)
 {
 	guint i;
 	const struct {
 		const gchar		*id;
-		EpcAppFilterOarsValue	 value;
+		MctAppFilterOarsValue	 value;
 		const gchar		*desc;
 	} tab[] =  {
-	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No cartoon violence") },
-	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Cartoon characters in unsafe situations") },
-	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Cartoon characters in aggressive conflict") },
-	{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic violence involving cartoon characters") },
-	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No fantasy violence") },
-	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Characters in unsafe situations easily distinguishable from reality") },
-	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Characters in aggressive conflict easily distinguishable from reality") },
-	{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic violence easily distinguishable from reality") },
-	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-realistic",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No realistic violence") },
-	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "violence-realistic", MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Mildly realistic characters in unsafe situations") },
-	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "violence-realistic",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Depictions of realistic characters in aggressive conflict") },
-	{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-realistic",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic violence involving realistic characters") },
-	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No bloodshed") },
-	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Unrealistic bloodshed") },
-	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Realistic bloodshed") },
-	{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Depictions of bloodshed and the mutilation of body parts") },
-	{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-sexual",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No sexual violence") },
-	{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-sexual",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Rape or other violent sexual behavior") },
-	{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "drugs-alcohol",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references to alcohol") },
-	{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "drugs-alcohol",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("References to alcoholic beverages") },
-	{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "drugs-alcohol",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Use of alcoholic beverages") },
-	{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "drugs-narcotics",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references to illicit drugs") },
-	{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "drugs-narcotics",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("References to illicit drugs") },
-	{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "drugs-narcotics",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Use of illicit drugs") },
-	{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "drugs-tobacco",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("References to tobacco products") },
-	{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "drugs-tobacco",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Use of tobacco products") },
-	{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "sex-nudity",		MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No nudity of any sort") },
-	{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "sex-nudity",		MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Brief artistic nudity") },
-	{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "sex-nudity",		MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Prolonged nudity") },
-	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references or depictions of sexual nature") },
-	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Provocative references or depictions") },
-	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Sexual references or depictions") },
-	{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic sexual behavior") },
-	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No profanity of any kind") },
-	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Mild or infrequent use of profanity") },
-	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Moderate use of profanity") },
-	{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Strong or frequent use of profanity") },
-	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No inappropriate humor") },
-	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Slapstick humor") },
-	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Vulgar or bathroom humor") },
-	{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Mature or sexual humor") },
-	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No discriminatory language of any kind") },
-	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Negativity towards a specific group of people") },
-	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Discrimination designed to cause emotional harm") },
-	{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Explicit discrimination based on gender, sexuality, race or religion") },
-	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "money-advertising", MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No advertising of any kind") },
-	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "money-advertising", MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Product placement") },
-	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "money-advertising", MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Explicit references to specific brands or trademarked products") },
-	{ "money-advertising", EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "money-advertising", MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Users are encouraged to purchase specific real-world items") },
-	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No gambling of any kind") },
-	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Gambling on random events using tokens or credits") },
-	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Gambling using “play” money") },
-	{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Gambling using real money") },
-	{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "money-purchasing",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No ability to spend money") },
-	{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_MILD,		/* v1.1 */
+	{ "money-purchasing",	MCT_APP_FILTER_OARS_VALUE_MILD,		/* v1.1 */
 	/* TRANSLATORS: content rating description */
 	_("Users are encouraged to donate real money") },
-	{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "money-purchasing",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Ability to spend real money in-game") },
-	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No way to chat with other users") },
-	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("User-to-user game interactions without chat functionality") },
-	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Moderated chat functionality between users") },
-	{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Uncontrolled chat functionality between users") },
-	{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "social-audio",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No way to talk with other users") },
-	{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "social-audio",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Uncontrolled audio or video chat functionality between users") },
-	{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "social-contacts",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No sharing of social network usernames or email addresses") },
-	{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "social-contacts",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Sharing social network usernames or email addresses") },
-	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "social-info",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No sharing of user information with 3rd parties") },
-	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MILD,		/* v1.1 */
+	{ "social-info",	MCT_APP_FILTER_OARS_VALUE_MILD,		/* v1.1 */
 	/* TRANSLATORS: content rating description */
 	_("Checking for the latest application version") },
-	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	/* v1.1 */
+	{ "social-info",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	/* v1.1 */
 	/* TRANSLATORS: content rating description */
 	_("Sharing diagnostic data that does not let others identify the user") },
-	{ "social-info",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "social-info",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Sharing information that lets others identify the user") },
-	{ "social-location",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "social-location",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No sharing of physical location to other users") },
-	{ "social-location",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "social-location",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Sharing physical location to other users") },
 
 	/* v1.1 */
-	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references to homosexuality") },
-	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Indirect references to homosexuality") },
-	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Kissing between people of the same gender") },
-	{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic sexual behavior between people of the same gender") },
-	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references to prostitution") },
-	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Indirect references to prostitution") },
-	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Direct references to prostitution") },
-	{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic depictions of the act of prostitution") },
-	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references to adultery") },
-	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Indirect references to adultery") },
-	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Direct references to adultery") },
-	{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic depictions of the act of adultery") },
-	{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "sex-appearance",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No sexualized characters") },
-	{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "sex-appearance",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Scantily clad human characters") },
-	{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "sex-appearance",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Overtly sexualized human characters") },
-	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references to desecration") },
-	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Depictions or references to historical desecration") },
-	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Depictions of modern-day human desecration") },
-	{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic depictions of modern-day desecration") },
-	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No visible dead human remains") },
-	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Visible dead human remains") },
-	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Dead human remains that are exposed to the elements") },
-	{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic depictions of desecration of human bodies") },
-	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_NONE,
+	{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_NONE,
 	/* TRANSLATORS: content rating description */
 	_("No references to slavery") },
-	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MILD,
+	{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_MILD,
 	/* TRANSLATORS: content rating description */
 	_("Depictions or references to historical slavery") },
-	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,
+	{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_MODERATE,
 	/* TRANSLATORS: content rating description */
 	_("Depictions of modern-day slavery") },
-	{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,
+	{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_INTENSE,
 	/* TRANSLATORS: content rating description */
 	_("Graphic depictions of modern-day slavery") },
 	{ NULL, 0, NULL } };
@@ -801,110 +801,110 @@ gs_utils_content_rating_get_ages (GsContentRatingSystem system)
 
 const struct {
 	const gchar		*id;
-	EpcAppFilterOarsValue	 value;
+	MctAppFilterOarsValue	 value;
 	guint			 csm_age;
 } id_to_csm_age[] =  {
 /* v1.0 */
-{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MILD,		3 },
-{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	4 },
-{ "violence-cartoon",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	6 },
-{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MILD,		3 },
-{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	7 },
-{ "violence-fantasy",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	8 },
-{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MILD,		4 },
-{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	9 },
-{ "violence-realistic",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	14 },
-{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MILD,		9 },
-{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	11 },
-{ "violence-bloodshed",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "violence-sexual",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MILD,		11 },
-{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
-{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
-{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
-{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_NONE,		0 },
-{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MILD,		10 },
-{ "drugs-tobacco",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
-{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
-{ "sex-nudity",		EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
-{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MILD,		13 },
-{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
-{ "sex-themes",		EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
-{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MILD,		8  },
-{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	11 },
-{ "language-profanity",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	14 },
-{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MILD,		3  },
-{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	8  },
-{ "language-humor",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	14 },
-{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_NONE,	0  },
-{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MILD,	9  },
-{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_MODERATE,10 },
-{ "language-discrimination", EPC_APP_FILTER_OARS_VALUE_INTENSE,	11 },
-{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_MILD,		7  },
-{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	8  },
-{ "money-advertising",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	10 },
-{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MILD,		7  },
-{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
-{ "money-gambling",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
-{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MILD,		4  },
-{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
-{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	13 },
-{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "social-audio",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
-{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "social-contacts",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	12 },
-{ "social-info",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "social-info",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	13 },
-{ "social-location",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "social-location",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	13 },
+{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_MILD,		3 },
+{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	4 },
+{ "violence-cartoon",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	6 },
+{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_MILD,		3 },
+{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	7 },
+{ "violence-fantasy",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	8 },
+{ "violence-realistic",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-realistic",	MCT_APP_FILTER_OARS_VALUE_MILD,		4 },
+{ "violence-realistic",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	9 },
+{ "violence-realistic",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	14 },
+{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_MILD,		9 },
+{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	11 },
+{ "violence-bloodshed",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "violence-sexual",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "violence-sexual",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "drugs-alcohol",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "drugs-alcohol",	MCT_APP_FILTER_OARS_VALUE_MILD,		11 },
+{ "drugs-alcohol",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "drugs-narcotics",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "drugs-narcotics",	MCT_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "drugs-narcotics",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "drugs-tobacco",	MCT_APP_FILTER_OARS_VALUE_NONE,		0 },
+{ "drugs-tobacco",	MCT_APP_FILTER_OARS_VALUE_MILD,		10 },
+{ "drugs-tobacco",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "sex-nudity",		MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-nudity",		MCT_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "sex-nudity",		MCT_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_MILD,		13 },
+{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-themes",		MCT_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_MILD,		8  },
+{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	11 },
+{ "language-profanity",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	14 },
+{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_MILD,		3  },
+{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	8  },
+{ "language-humor",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	14 },
+{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_NONE,	0  },
+{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_MILD,	9  },
+{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_MODERATE,10 },
+{ "language-discrimination", MCT_APP_FILTER_OARS_VALUE_INTENSE,	11 },
+{ "money-advertising",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "money-advertising",	MCT_APP_FILTER_OARS_VALUE_MILD,		7  },
+{ "money-advertising",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	8  },
+{ "money-advertising",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	10 },
+{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_MILD,		7  },
+{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "money-gambling",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "money-purchasing",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "money-purchasing",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_MILD,		4  },
+{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	13 },
+{ "social-audio",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-audio",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "social-contacts",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-contacts",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	12 },
+{ "social-info",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-info",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	13 },
+{ "social-location",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "social-location",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	13 },
 /* v1.1 additions */
-{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MILD,		0  },
-{ "social-info",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
-{ "money-purchasing",	EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
-{ "social-chat",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
-{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MILD,		10 },
-{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	13 },
-{ "sex-homosexuality",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MILD,		12 },
-{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	14 },
-{ "sex-prostitution",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MILD,		8  },
-{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
-{ "sex-adultery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	10 },
-{ "sex-appearance",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	15 },
-{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MILD,		13 },
-{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	15 },
-{ "violence-worship",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_NONE,	0  },
-{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MILD,	13 },
-{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_MODERATE,	15 },
-{ "violence-desecration", EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
-{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_NONE,		0  },
-{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MILD,		13 },
-{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_MODERATE,	15 },
-{ "violence-slavery",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "social-info",	MCT_APP_FILTER_OARS_VALUE_MILD,		0  },
+{ "social-info",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "money-purchasing",	MCT_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "social-chat",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_MILD,		10 },
+{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	13 },
+{ "sex-homosexuality",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_MILD,		12 },
+{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	14 },
+{ "sex-prostitution",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_MILD,		8  },
+{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "sex-adultery",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "sex-appearance",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "sex-appearance",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	10 },
+{ "sex-appearance",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	15 },
+{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_MILD,		13 },
+{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	15 },
+{ "violence-worship",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_NONE,	0  },
+{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_MILD,	13 },
+{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_MODERATE,	15 },
+{ "violence-desecration", MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
+{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_NONE,		0  },
+{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_MILD,		13 },
+{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_MODERATE,	15 },
+{ "violence-slavery",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	18 },
 
 /* EOS customisation to add at least one CSM ↔ OARS mapping for ages 16 and 17,
  * as these are used in many locale-specific ratings systems. Without them,
@@ -915,14 +915,14 @@ const struct {
  * which users are allowed to see intense content in these two categories.
  *
  * See https://phabricator.endlessm.com/T23897#666769. */
-{ "drugs-alcohol",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	16 },
-{ "drugs-narcotics",	EPC_APP_FILTER_OARS_VALUE_INTENSE,	17 },
+{ "drugs-alcohol",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	16 },
+{ "drugs-narcotics",	MCT_APP_FILTER_OARS_VALUE_INTENSE,	17 },
 { NULL, 0, 0 } };
 
 /**
  * as_content_rating_id_value_to_csm_age:
  * @id: the subsection ID e.g. "violence-cartoon"
- * @value: the #AsContentRatingValue, e.g. %EPC_APP_FILTER_OARS_VALUE_INTENSE
+ * @value: the #AsContentRatingValue, e.g. %MCT_APP_FILTER_OARS_VALUE_INTENSE
  *
  * Gets the Common Sense Media approved age for a specific rating level.
  *
@@ -931,7 +931,7 @@ const struct {
  * Since: 0.5.12
  **/
 guint
-as_content_rating_id_value_to_csm_age (const gchar *id, EpcAppFilterOarsValue value)
+as_content_rating_id_value_to_csm_age (const gchar *id, MctAppFilterOarsValue value)
 {
 	guint i;
 	for (i = 0; id_to_csm_age[i].id != NULL; i++) {
@@ -947,17 +947,17 @@ as_content_rating_id_value_to_csm_age (const gchar *id, EpcAppFilterOarsValue va
  * @id: the subsection ID e.g. "violence-cartoon"
  * @age: the age
  *
- * Gets the #EpcAppFilterOarsValue for a given age.
+ * Gets the #MctAppFilterOarsValue for a given age.
  *
- * Returns: the #EpcAppFilterOarsValue
+ * Returns: the #MctAppFilterOarsValue
  **/
-EpcAppFilterOarsValue
+MctAppFilterOarsValue
 as_content_rating_id_csm_age_to_value (const gchar *id, guint age)
 {
-	EpcAppFilterOarsValue value;
+	MctAppFilterOarsValue value;
 	guint i;
 
-	value = EPC_APP_FILTER_OARS_VALUE_UNKNOWN;
+	value = MCT_APP_FILTER_OARS_VALUE_UNKNOWN;
 
 	for (i = 0; id_to_csm_age[i].id != NULL; i++) {
 		if (age >= id_to_csm_age[i].csm_age &&

--- a/panels/user-accounts/gs-content-rating.h
+++ b/panels/user-accounts/gs-content-rating.h
@@ -24,7 +24,7 @@
 G_BEGIN_DECLS
 
 #include <glib-object.h>
-#include <libeos-parental-controls/app-filter.h>
+#include <libmalcontent/malcontent.h>
 
 typedef enum {
 	GS_CONTENT_RATING_SYSTEM_UNKNOWN,
@@ -51,11 +51,11 @@ const gchar *gs_utils_content_rating_age_to_str (GsContentRatingSystem system,
 						 guint age);
 GsContentRatingSystem gs_utils_content_rating_system_from_locale (const gchar *locale);
 const gchar *gs_content_rating_key_value_to_str (const gchar *id,
-						 EpcAppFilterOarsValue value);
+						 MctAppFilterOarsValue value);
 const gchar *gs_content_rating_system_to_str (GsContentRatingSystem system);
 const gchar * const *gs_utils_content_rating_get_values (GsContentRatingSystem system);
 const guint *gs_utils_content_rating_get_ages (GsContentRatingSystem system);
-guint as_content_rating_id_value_to_csm_age (const gchar *id, EpcAppFilterOarsValue value);
-EpcAppFilterOarsValue as_content_rating_id_csm_age_to_value (const gchar *id, guint age);
+guint as_content_rating_id_value_to_csm_age (const gchar *id, MctAppFilterOarsValue value);
+MctAppFilterOarsValue as_content_rating_id_csm_age_to_value (const gchar *id, guint age);
 
 G_END_DECLS

--- a/panels/user-accounts/meson.build
+++ b/panels/user-accounts/meson.build
@@ -172,7 +172,7 @@ deps = common_deps + [
   m_dep,
   polkit_gobject_dep,
   dependency('pwquality', version: '>= 1.2.2'),
-  dependency('eos-parental-controls-0'),
+  dependency('malcontent-0', version: '>= 0.3.0'),
   dependency('flatpak')
 ]
 


### PR DESCRIPTION
eos-parental-controls is renamed to malcontent for upstreaming
purposes hence, we should move to libmalcontent so that it can
be dropped from Endless package-management system as well.

This commit does not introduce any functional changes. In the next
rebase cycle, this commit can be squashed with the commit where the
parental controls is introduced (c315ab1ed).

https://phabricator.endlessm.com/T26995