### PR TITLE
applications: Filter out "eos-link-" Endless-specific webapps

### DIFF
--- a/panels/applications/cc-applications-panel.c
+++ b/panels/applications/cc-applications-panel.c
@@ -39,6 +39,7 @@
 #define MASTER_SCHEMA "org.gnome.desktop.notifications"
 #define APP_SCHEMA MASTER_SCHEMA ".application"
 #define APP_PREFIX "/org/gnome/desktop/notifications/application/"
+#define EOS_LINK_PREFIX "eos-link-"
 
 struct _CcApplicationsPanel
 {
@@ -1410,13 +1411,13 @@ populate_applications (CcApplicationsPanel *self)
       GtkWidget *row;
       g_autofree gchar *id = NULL;
 
-      if (!g_app_info_should_show (info))
+      id = get_app_id (info);
+      if (!g_app_info_should_show (info) || g_str_has_prefix (id, EOS_LINK_PREFIX))
         continue;
 
       row = GTK_WIDGET (cc_applications_row_new (info));
       gtk_list_box_insert (GTK_LIST_BOX (self->sidebar_listbox), row, -1);
 
-      id = get_app_id (info);
       if (g_strcmp0 (id, self->current_app_id) == 0)
         gtk_list_box_select_row (GTK_LIST_BOX (self->sidebar_listbox), GTK_LIST_BOX_ROW (row));
     }

--- a/panels/applications/cc-applications-panel.ui
+++ b/panels/applications/cc-applications-panel.ui
@@ -410,7 +410,7 @@
   </object>
   <object class="GtkButton" id="header_button">
     <property name="visible">1</property>
-    <property name="label" translatable="yes">Open in Software</property>
+    <property name="label" translatable="yes">Open in App Center</property>
   </object>
   <object class="GtkListBox" id="sidebar_listbox">
     <property name="visible">1</property>


### PR DESCRIPTION
A web app can be added to desktop for easy access via:
Right-click the desktop → Add Website...
These web app have app-id prefixed with "eos-link-".

gnome-control-center 3.32 introduced a new "Applications"
panels for applications' managing details (managing permissions,
disk space usage etc.). The enormous list of "eos-link-"
webapps ended up in this applications panel where basically
have very minimal information to show/manage. Also, many of
them are non-English speaking apps, which inhibits the purpose
of search in this particular panel.

https://phabricator.endlessm.com/T27007