### PR TITLE
applications: hide “Show in App Center” for App Center

### DIFF
--- a/panels/applications/cc-applications-panel.c
+++ b/panels/applications/cc-applications-panel.c
@@ -1386,7 +1386,6 @@ update_panel (CcApplicationsPanel *self,
 
   gtk_label_set_label (GTK_LABEL (self->title_label), g_app_info_get_display_name (info));
   gtk_stack_set_visible_child_name (GTK_STACK (self->stack), "settings");
-  gtk_widget_show (self->header_button);
 
   g_clear_pointer (&self->current_app_id, g_free);
   g_clear_pointer (&self->current_flatpak_id, g_free);
@@ -1398,6 +1397,12 @@ update_panel (CcApplicationsPanel *self,
 
   self->current_app_id = get_app_id (info);
   self->current_flatpak_id = get_flatpak_id (info);
+
+  /* Don't show “Open in Software” button for Software itself. */
+  {
+    gboolean is_software = g_strcmp0 (self->current_app_id, "org.gnome.Software") == 0;
+    gtk_widget_set_visible (self->header_button, !is_software);
+  }
 }
 
 static void


### PR DESCRIPTION
In Endless, gnome-software is patched to not display itself. (The
rationale is that it looks odd for the App Center to be listed as an app
inside itself; everywhere else we treat it as a system component, not as
something with its own “personality”.)

As a result, selecting App Center in this panel then clicking “Show in
App Center” launches the App Center with a “No Application Found” error.

Hide this button when displaying the App Center page in the applications
panel.

https://phabricator.endlessm.com/T27065