### PR TITLE
parental controls: Add setting to disable all browsers

### DIFF
--- a/panels/user-accounts/cc-app-permissions.ui
+++ b/panels/user-accounts/cc-app-permissions.ui
@@ -70,6 +70,79 @@
       </packing>
     </child>
 
+    <!-- Restricted Web Browsers -->
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="xalign">0.0</property>
+        <property name="label" translatable="yes">Restrict Web Browsers</property>
+        <attributes>
+          <attribute name="weight" value="bold" />
+        </attributes>
+      </object>
+      <packing>
+        <property name="top-attach">3</property>
+        <property name="left-attach">0</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="xalign">0.0</property>
+        <property name="label" translatable="yes">Prevent this user from running web browsers by turning them off below. Note that if the computer is connected to the internet, limited web content may still be available in other applications.</property>
+        <property name="wrap">True</property>
+        <property name="use-underline">True</property>
+        <property name="mnemonic-widget">allow_web_browsers_switch</property>
+        <attributes>
+          <attribute name="scale" value="0.83333" />
+        </attributes>
+        <style>
+          <class name="dim-label" />
+        </style>
+      </object>
+      <packing>
+        <property name="top-attach">4</property>
+        <property name="left-attach">0</property>
+      </packing>
+    </child>
+
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="spacing">12</property>
+
+        <child>
+          <object class="GtkLabel" id="browsers_label">
+            <property name="visible">True</property>
+            <property name="xalign">1.0</property>
+            <property name="label" translatable="yes">Web _Browsers:</property>
+            <property name="wrap">True</property>
+            <property name="use-underline">True</property>
+            <property name="mnemonic-widget">allow_web_browsers_switch</property>
+            <style>
+              <class name="dim-label" />
+            </style>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkSwitch" id="allow_web_browsers_switch">
+            <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="halign">start</property>
+            <signal name="notify::active" handler="on_allow_web_browsers_switch_active_changed_cb" object="CcAppPermissions" swapped="no" />
+          </object>
+        </child>
+
+      </object>
+      <packing>
+        <property name="top-attach">5</property>
+        <property name="left-attach">0</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+
     <!-- App Center Restrictions -->
     <child>
       <object class="GtkLabel">
@@ -82,7 +155,7 @@
         </attributes>
       </object>
       <packing>
-        <property name="top-attach">3</property>
+        <property name="top-attach">6</property>
         <property name="left-attach">0</property>
       </packing>
     </child>
@@ -117,7 +190,7 @@
 
       </object>
       <packing>
-        <property name="top-attach">4</property>
+        <property name="top-attach">7</property>
         <property name="left-attach">0</property>
         <property name="width">2</property>
       </packing>
@@ -153,7 +226,7 @@
 
       </object>
       <packing>
-        <property name="top-attach">5</property>
+        <property name="top-attach">8</property>
         <property name="left-attach">0</property>
         <property name="width">2</property>
       </packing>
@@ -190,7 +263,7 @@
 
       </object>
       <packing>
-        <property name="top-attach">6</property>
+        <property name="top-attach">9</property>
         <property name="left-attach">0</property>
         <property name="width">2</property>
       </packing>
@@ -212,6 +285,7 @@
   <object class="GtkSizeGroup">
     <property name="mode">horizontal</property>
     <widgets>
+      <widget name="browsers_label" />
       <widget name="app_restriction_label" />
       <widget name="user_installation_label" />
       <widget name="system_installation_label" />

--- a/panels/user-accounts/meson.build
+++ b/panels/user-accounts/meson.build
@@ -172,7 +172,7 @@ deps = common_deps + [
   m_dep,
   polkit_gobject_dep,
   dependency('pwquality', version: '>= 1.2.2'),
-  dependency('malcontent-0', version: '>= 0.3.0'),
+  dependency('malcontent-0', version: '>= 0.4.0'),
   dependency('flatpak')
 ]
 


### PR DESCRIPTION
Note that in this implementation individual browsers are not listed in the restrict apps list and can only be disabled via the `Web Browsers` switch. This was done on purpose as supporting both options to disable browsers would require more discussions on the UI/usability side of things. See https://phabricator.endlessm.com/T26895#730545 for more details.

https://phabricator.endlessm.com/T27064