### PR TITLE
parental controls: Hide defunct switches for administrators

### DIFF
--- a/panels/user-accounts/cc-app-permissions.ui
+++ b/panels/user-accounts/cc-app-permissions.ui
@@ -168,7 +168,7 @@
 
         <child>
           <object class="GtkLabel" id="user_installation_label">
-            <property name="visible">True</property>
+            <property name="visible" bind-source="allow_user_installation_switch" bind-property="visible" bind-flags="default|sync-create" />
             <property name="xalign">1.0</property>
             <property name="label" translatable="yes">App _Installation</property>
             <property name="wrap">True</property>
@@ -204,7 +204,7 @@
 
         <child>
           <object class="GtkLabel" id="system_installation_label">
-            <property name="visible">True</property>
+            <property name="visible" bind-source="allow_system_installation_switch" bind-property="visible" bind-flags="default|sync-create" />
             <property name="xalign">1.0</property>
             <property name="label" translatable="yes">Install Apps for All _Users</property>
             <property name="wrap">True</property>


### PR DESCRIPTION
Particularly, hide "App Installation" and "Install Apps for all Users".
The reason is that, we will always allow administrators to install
apps without the polkit challenge, as this was the default behaviour
historically.

During next rebase, this commit can be squashed with:
c825ff3fd parental-controls: Enable parental-controls for Administrators

https://phabricator.endlessm.com/T26968