### PR TITLE
applications: hide "Get ____" launchers

### DIFF
--- a/panels/applications/cc-applications-panel.c
+++ b/panels/applications/cc-applications-panel.c
@@ -1405,6 +1405,21 @@ update_panel (CcApplicationsPanel *self,
   }
 }
 
+/* Checks whether the given @info is a pseudo-application from
+ * eos-application-tools (which opens the app center if the app is not
+ * installed, or forward to the app if it is).
+ */
+static gboolean
+has_replaced_by (GAppInfo *info)
+{
+  g_autofree gchar *replaced_by = NULL;
+
+  if (G_IS_DESKTOP_APP_INFO (info))
+    replaced_by = g_desktop_app_info_get_string (G_DESKTOP_APP_INFO (info), "X-Endless-Replaced-By");
+
+  return replaced_by != NULL;
+}
+
 static void
 populate_applications (CcApplicationsPanel *self)
 {
@@ -1425,7 +1440,8 @@ populate_applications (CcApplicationsPanel *self)
       id = get_app_id (info);
       if (!g_app_info_should_show (info) ||
           !mct_app_filter_is_appinfo_allowed (self->app_filter, info) ||
-          g_str_has_prefix (id, EOS_LINK_PREFIX))
+          g_str_has_prefix (id, EOS_LINK_PREFIX) ||
+          has_replaced_by (info))
         {
           continue;
         }


### PR DESCRIPTION
These are not "real" applications, so we should hide them from the
Applications panel (just as we do for web apps).

https://phabricator.endlessm.com/T27105