### PR TITLE
Cherry-pick upstream fix for crash on clicking 'Search Locations'

### DIFF
--- a/panels/search/cc-search-locations-dialog.c
+++ b/panels/search/cc-search-locations-dialog.c
@@ -261,6 +261,7 @@ get_tracker_locations (CcSearchLocationsDialog *self)
       path = path_from_tracker_dir (locations[idx]);
 
       location = g_slice_new0 (Place);
+      location->dialog = self;
       location->location = g_file_new_for_commandline_arg (path);
       location->display_name = g_file_get_basename (location->location);
       location->place_type = PLACE_OTHER;

--- a/panels/sound/cc-volume-slider.c
+++ b/panels/sound/cc-volume-slider.c
@@ -20,7 +20,6 @@
 #include <math.h>
 #include <pulse/pulseaudio.h>
 #include <gvc-mixer-control.h>
-#include <canberra-gtk.h>
 
 #include "cc-sound-resources.h"
 #include "cc-volume-slider.h"


### PR DESCRIPTION
These are the only two non-translation commits on the gnome-3-34 branch since the merge base between our master and gnome-3-34, namely e369c8c19772368c68faa13b9d31999fc0a5fe87.

I have not merged the gnome-3-34 branch for lack of https://gitlab.gnome.org/wjt/translate-o-tron-3000/issues/1.

https://phabricator.endlessm.com/T27886