### PR TITLE
display: Adapt primary display description for EndlessOS

### DIFF
--- a/panels/display/cc-display-panel.ui
+++ b/panels/display/cc-display-panel.ui
@@ -219,7 +219,7 @@
                                           <object class="HdyComboRow" id="primary_display_row">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="subtitle">Contains top bar and Activities</property>
+                                            <property name="subtitle">Contains task bar</property>
                                             <property name="title">Primary Display</property>
                                             <signal name="notify::selected-index" handler="on_primary_display_selected_index_changed_cb" swapped="yes"/>
                                           </object>


### PR DESCRIPTION
On EndlessOS, the primary display contains the task bar, not the top bar
nor the Activities.

https://phabricator.endlessm.com/T27898