### PR TITLE
display: mark 3 missed translatable strings

### DIFF
--- a/panels/display/cc-display-panel.ui
+++ b/panels/display/cc-display-panel.ui
@@ -219,8 +219,8 @@
                                           <object class="HdyComboRow" id="primary_display_row">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="subtitle">Contains top bar and Activities</property>
-                                            <property name="title">Primary Display</property>
+                                            <property name="subtitle" translatable="yes">Contains top bar and Activities</property>
+                                            <property name="title" translatable="yes">Primary Display</property>
                                             <signal name="notify::selected-index" handler="on_primary_display_selected_index_changed_cb" swapped="yes"/>
                                           </object>
                                         </child>
@@ -384,7 +384,7 @@
                                               <object class="HdyComboRow">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
-                                                <property name="title">Active Display</property>
+                                                <property name="title" translatable="yes">Active Display</property>
                                               </object>
                                             </child>
                                           </object>

--- a/panels/display/cc-display-panel.ui
+++ b/panels/display/cc-display-panel.ui
@@ -219,7 +219,7 @@
                                           <object class="HdyComboRow" id="primary_display_row">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="subtitle" translatable="yes">Contains top bar and Activities</property>
+                                            <property name="subtitle" translatable="yes">Contains task bar</property>
                                             <property name="title" translatable="yes">Primary Display</property>
                                             <signal name="notify::selected-index" handler="on_primary_display_selected_index_changed_cb" swapped="yes"/>
                                           </object>

--- a/panels/display/cc-display-panel.ui
+++ b/panels/display/cc-display-panel.ui
@@ -219,7 +219,7 @@
                                           <object class="HdyComboRow" id="primary_display_row">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="subtitle">Contains task bar</property>
+                                            <property name="subtitle">Contains top bar and Activities</property>
                                             <property name="title">Primary Display</property>
                                             <signal name="notify::selected-index" handler="on_primary_display_selected_index_changed_cb" swapped="yes"/>
                                           </object>

--- a/po/af.po
+++ b/po/af.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Afrikaans (http://www.transifex.com/endless-os/gnome-control-center/language/af/)\n"
 "MIME-Version: 1.0\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Tuis"
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "Huidige agtergrond"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktiwiteite"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr "Dupliseer"
 msgid "Display Mode"
 msgstr "Skermmodus"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primêre skerm"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1409,6 +1413,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Skerm uitleg"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5778,11 +5786,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "taal;uitleg;sleutelbord;toevoer;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Kies ligging"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6103,7 +6111,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8536,6 +8544,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/am.po
+++ b/po/am.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Amharic (http://www.transifex.com/endless-os/gnome-control-center/language/am/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/an.po
+++ b/po/an.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Vicki Niu <vicki@endlessm.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Aragonese (http://www.transifex.com/endless-os/gnome-control-center/language/an/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Domicilio"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Fondo actual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Actividatz"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Espiello"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1407,6 +1411,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5777,11 +5785,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Distribución;Teclau;Dentrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Seleccionar una ubicación"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Acceptar"
 
@@ -6102,7 +6110,7 @@ msgstr "Volumen"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ar.po
+++ b/po/ar.po
@@ -19,9 +19,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:58+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/endless-os/gnome-control-center/language/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,7 +67,7 @@ msgstr "له وصول إلى الشبكة"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "البداية"
 
@@ -367,7 +367,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -426,10 +426,6 @@ msgstr "الخلفية الحالية"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "الأنشطة"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1408,6 +1404,14 @@ msgstr "طابق"
 msgid "Display Mode"
 msgstr "نمط العرض"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "الشاشة الرئيسية"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1417,6 +1421,10 @@ msgstr "اسحب الشاشات لتطابق ترتيبها في الطبيعة.
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "ترتيب الشاشات"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5826,11 +5834,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "اللغة;التخطيط;مفاتيح;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "اختر مكانًا"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_نعم"
 
@@ -6151,7 +6159,7 @@ msgstr "شدة الصوت"
 msgid "Alert Sound"
 msgstr "صوت التنبيه"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "١٠٠٪"
@@ -8593,6 +8601,16 @@ msgstr "إظهار التحذير عند تشغيل بنية تطوير الإع
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "ما إذا كان يجب أن تُظهر الإعدادات تحذيراً عند تشغيل بنية التطوير."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/as.po
+++ b/po/as.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:05+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Assamese (http://www.transifex.com/endless-os/gnome-control-center/language/as/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "গৃহ"
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "বৰ্তমান পটভূমী"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "কাৰ্য্যসমূহ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr "মিৰৰ"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5778,11 +5786,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "অবস্থান বাছক"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ঠিক আছে (_O)"
 
@@ -6103,7 +6111,7 @@ msgstr "ভলিউম"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "১০০%"
@@ -8536,6 +8544,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ast.po
+++ b/po/ast.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Asturian (http://www.transifex.com/endless-os/gnome-control-center/language/ast/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Carpeta personal"
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "Fondu actual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Actividaes"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5778,11 +5786,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6103,7 +6111,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8536,6 +8544,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/az.po
+++ b/po/az.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Azerbaijani (http://www.transifex.com/endless-os/gnome-control-center/language/az/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1398,6 +1394,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5776,11 +5784,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6101,7 +6109,7 @@ msgstr "Səs"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8534,6 +8542,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/be.po
+++ b/po/be.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Belarusian (http://www.transifex.com/endless-os/gnome-control-center/language/be/)\n"
 "MIME-Version: 1.0\n"
@@ -62,7 +62,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Дом"
 
@@ -362,7 +362,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -421,10 +421,6 @@ msgstr "Цяперашні абрус"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Заняткі"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1403,6 +1399,14 @@ msgstr "Адлюстроўваць"
 msgid "Display Mode"
 msgstr "Рэжым манітора"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Асноўны манітор"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Парадак манітораў"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5801,11 +5809,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Мова;Раскладка;Клавіятура;Увод;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Выбар мясцовасці"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Добра"
 
@@ -6126,7 +6134,7 @@ msgstr "Гучнасць"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8564,6 +8572,16 @@ msgstr "Паказваць папярэджанне пры запуску вер
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Ці паказваць папярэджанне пры запуску версіі для распрацоўкі."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/bg.po
+++ b/po/bg.po
@@ -18,8 +18,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/endless-os/gnome-control-center/language/bg/)\n"
 "MIME-Version: 1.0\n"
@@ -66,7 +66,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Домашна папка"
 
@@ -366,7 +366,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -425,10 +425,6 @@ msgstr "Текущ фон"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Дейности"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1407,6 +1403,14 @@ msgstr "Еднакво изображение"
 msgid "Display Mode"
 msgstr "Режим на екрана"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Основен екран"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1416,6 +1420,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Подредба на екраните"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5785,11 +5793,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "език;подредба;клавиатура;вход;language;layout;keyboard;input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Избор на регион"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Добре"
 
@@ -6110,7 +6118,7 @@ msgstr "Сила на звука"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100 %"
@@ -8543,6 +8551,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/bn.po
+++ b/po/bn.po
@@ -15,9 +15,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:01+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Bengali (http://www.transifex.com/endless-os/gnome-control-center/language/bn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -63,7 +63,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "নীড় "
 
@@ -363,7 +363,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -422,10 +422,6 @@ msgstr "বর্তমানের পটভূমি"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "অ্যাক্টিভিটিজ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1404,6 +1400,14 @@ msgstr "প্রতিবিম্ব "
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5782,11 +5790,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ভাষা;লেআউট;কীবোর্ড;ইনপুট; "
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "স্থান নির্বাচন করুন "
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_ওকে "
 
@@ -6107,7 +6115,7 @@ msgstr "ভলিউম"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "১০০%"
@@ -8540,6 +8548,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:14+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Bengali (India) (http://www.transifex.com/endless-os/gnome-control-center/language/bn_IN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "গৃহ"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "বর্তমান পটভূমি"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "ক্রিয়াকলাপ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "মিরর"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1407,6 +1411,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5777,11 +5785,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ভাষা;সজ্জা;কীবোর্ড;ইনপুট;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "অবস্থান নির্বাচন করুন"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ঠিক অাছে (_O)"
 
@@ -6102,7 +6110,7 @@ msgstr "ভলিউম"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "১০০%"
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/bo.po
+++ b/po/bo.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Tibetan (http://www.transifex.com/endless-os/gnome-control-center/language/bo/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5764,11 +5772,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6089,7 +6097,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8520,6 +8528,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/br.po
+++ b/po/br.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Vicki Niu <vicki@endlessm.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Breton (http://www.transifex.com/endless-os/gnome-control-center/language/br/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1398,6 +1394,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5806,11 +5814,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "Mat e_o"
 
@@ -6131,7 +6139,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "10%"
@@ -8570,6 +8578,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/bs.po
+++ b/po/bs.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:57+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Bosnian (http://www.transifex.com/endless-os/gnome-control-center/language/bs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Početna"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Trenutna pozadina"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivnosti"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Ogledalo"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1407,6 +1411,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5787,11 +5795,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Jezik;Raspored;Tastatura;Ulaz;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Odaberi Lokaciju"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "U _redu"
 
@@ -6112,7 +6120,7 @@ msgstr "Jačina"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8547,6 +8555,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ca.po
+++ b/po/ca.po
@@ -17,9 +17,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:17+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/endless-os/gnome-control-center/language/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Té accés a la xarxa"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Inici"
 
@@ -365,7 +365,7 @@ msgstr "Selecciona una imatge"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -424,10 +424,6 @@ msgstr "Imatge de fons actual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Afegeix una imatge…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activitats"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1406,6 +1402,14 @@ msgstr "Mirall"
 msgid "Display Mode"
 msgstr "Mode de pantalla"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Pantalla primària"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1415,6 +1419,10 @@ msgstr "Arrossegueu les pantalles perquè coincideixen amb la vostra configuraci
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Disposició de les pantalles"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5784,11 +5792,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposició;Teclat;Entrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Seleccioneu una ubicació"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_D'acord"
 
@@ -6109,7 +6117,7 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr "So d'alerta"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8543,6 +8551,16 @@ msgstr "Mostra un avís que s'executa un muntatge de desenvolupament del Paràme
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Si el Paràmetres ha de mostrar un avís que s'executa un muntatge de desenvolupament."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -16,8 +16,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Catalan (Valencian) (http://www.transifex.com/endless-os/gnome-control-center/language/ca@valencia/)\n"
 "MIME-Version: 1.0\n"
@@ -64,7 +64,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Inici"
 
@@ -364,7 +364,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -423,10 +423,6 @@ msgstr "Imatge de fons actual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activitats"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1405,6 +1401,14 @@ msgstr "Mirall"
 msgid "Display Mode"
 msgstr "Mode de pantalla"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Pantalla primària"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1414,6 +1418,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Disposició de les pantalles"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5783,11 +5791,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposició;Teclat;Entrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Seleccioneu una ubicació"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_D'acord"
 
@@ -6108,7 +6116,7 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8541,6 +8549,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/crh.po
+++ b/po/crh.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:56+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Crimean Turkish (http://www.transifex.com/endless-os/gnome-control-center/language/crh/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Ev"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr "Cari arqazemin"
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1398,6 +1394,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5776,11 +5784,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Til;Tizilim;Klavye;Kirdi;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Qonum Saylañız"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6101,7 +6109,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "%100"
@@ -8534,6 +8542,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/cs.po
+++ b/po/cs.po
@@ -24,9 +24,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:08+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Czech (http://www.transifex.com/endless-os/gnome-control-center/language/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -72,7 +72,7 @@ msgstr "Má přístup k síti"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Domů"
 
@@ -372,7 +372,7 @@ msgstr "Vyběr obrázku"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -431,10 +431,6 @@ msgstr "Aktuální pozadí"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Přidat obrázek…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Činnosti"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1413,6 +1409,14 @@ msgstr "Duplikovat"
 msgid "Display Mode"
 msgstr "Režim displeje"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Hlavní displej"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1422,6 +1426,10 @@ msgstr "Přesuňte displeje tak, aby odpovídaly fyzickému uspořádání. Nast
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Uspořádání displejů"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5811,11 +5819,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "jazyk;rozložení;klávesnice;vstup;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Vyberte umístění"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Budiž"
 
@@ -6136,7 +6144,7 @@ msgstr "Hlasitost"
 msgid "Alert Sound"
 msgstr "Zvuk upozornění"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8574,6 +8582,16 @@ msgstr "Zobrazit varování při spuštění vývojové sestavení"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Zda mají Nastavení zobrazit varování, když je spuštěno vývojové sestavení."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/csb.po
+++ b/po/csb.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Kashubian (http://www.transifex.com/endless-os/gnome-control-center/language/csb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5784,11 +5792,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6109,7 +6117,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8544,6 +8552,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/cy.po
+++ b/po/cy.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Welsh (http://www.transifex.com/endless-os/gnome-control-center/language/cy/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1400,6 +1396,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5798,11 +5806,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6123,7 +6131,7 @@ msgstr "Lefel Sain"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8560,6 +8568,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/da.po
+++ b/po/da.po
@@ -15,9 +15,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:17+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Danish (http://www.transifex.com/endless-os/gnome-control-center/language/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -63,7 +63,7 @@ msgstr "Har netværksadgang"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Hjem"
 
@@ -363,7 +363,7 @@ msgstr "Vælg et billede"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -422,10 +422,6 @@ msgstr "Nuværende baggrund"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Tilføj billede …"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktiviteter"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1404,6 +1400,14 @@ msgstr "Klon"
 msgid "Display Mode"
 msgstr "Skærmtilstand"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primær skærm"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1413,6 +1417,10 @@ msgstr "Træk skærme, så de passer til din fysiske opsætning af skærme. Væl
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Placering af skærme"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5782,11 +5790,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Sprog;Layout;Tastatur;Input;Inddata;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Vælg sted"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6107,7 +6115,7 @@ msgstr "Lydstyrke"
 msgid "Alert Sound"
 msgstr "Påmindelseslyd"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8541,6 +8549,16 @@ msgstr "Vis advarsel ved kørsel af udviklingsversionen af Indstillinger"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Om Indstillinger skal vise en advarsel ved kørsel af en udviklerversion."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/de.po
+++ b/po/de.po
@@ -25,9 +25,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:18+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: German (http://www.transifex.com/endless-os/gnome-control-center/language/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -73,7 +73,7 @@ msgstr "Hat Netwerkzugriff"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Persönlicher Ordner"
 
@@ -373,7 +373,7 @@ msgstr "Ein Bild wählen"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -432,10 +432,6 @@ msgstr "Aktueller Hintergrund"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Bild hinzufügen …"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivitäten"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1414,6 +1410,14 @@ msgstr "Bildschirm spiegeln"
 msgid "Display Mode"
 msgstr "Anzeigemodus"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primärer Bildschirm"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1423,6 +1427,10 @@ msgstr "Ziehen Sie Ihre Bildschirme und positionieren Sie diese entsprechend der
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Bildschirmanordnung"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5792,11 +5800,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Sprache;Belegung;Tastatur;Eingabe;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Ort wählen"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6117,7 +6125,7 @@ msgstr "Lautstärke"
 msgid "Alert Sound"
 msgstr "Warnton"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8551,6 +8559,16 @@ msgstr "Warnung anzeigen, wenn eine Entwicklerversion der Einstellungen ausgefü
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Legt fest, ob eine Warnung angezeigt wird, wenn eine Entwicklerversion der Einstellungen ausgeführt wird."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/dz.po
+++ b/po/dz.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Dzongkha (http://www.transifex.com/endless-os/gnome-control-center/language/dz/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "ཁྱིམ"
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5764,11 +5772,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6089,7 +6097,7 @@ msgstr "སྐད་ཤུགས"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8520,6 +8528,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/el.po
+++ b/po/el.po
@@ -20,9 +20,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:08+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Greek (http://www.transifex.com/endless-os/gnome-control-center/language/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -68,7 +68,7 @@ msgstr "Έχει πρόσβαση δικτύου"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Προσωπικός φάκελος"
 
@@ -368,7 +368,7 @@ msgstr "Επιλογή εικόνας"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -427,10 +427,6 @@ msgstr "Τρέχον παρασκήνιο"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Προσθήκη εικόνας…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Δραστηριότητες"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1409,6 +1405,14 @@ msgstr "Καθρέφτης"
 msgid "Display Mode"
 msgstr "Λειτουργία οθόνης"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Πρωτεύουσα οθόνη"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1418,6 +1422,10 @@ msgstr "Σύρετε τις οθόνες ώστε να ταιριάζουν με
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Διάταξη οθόνης"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5787,11 +5795,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Γλώσσα;Διάταξη;Πληκτρολόγιο;Είσοδος;Language;Layout;Keyboard;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Επιλογή περιοχής"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Εντάξει"
 
@@ -6112,7 +6120,7 @@ msgstr "Ένταση"
 msgid "Alert Sound"
 msgstr "Ήχος ειδοποίησης"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8546,6 +8554,16 @@ msgstr "Προβολή προειδοποίησης κατά την εκτέλε
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Αν οι Ρυθμίσεις πρέπει να εμφανίζουν μια προειδοποίηση κατά την εκτέλεση μιας έκδοσης ανάπτυξης."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: English (Canada) (http://www.transifex.com/endless-os/gnome-control-center/language/en_CA/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Home"
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -14,9 +14,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:09+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/endless-os/gnome-control-center/language/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -62,7 +62,7 @@ msgstr "Has network access"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Home"
 
@@ -362,7 +362,7 @@ msgstr "Select a picture"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -421,10 +421,6 @@ msgstr "Current background"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Add Picture…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activities"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1403,6 +1399,14 @@ msgstr "Mirror"
 msgid "Display Mode"
 msgstr "Display Mode"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primary Display"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr "Drag displays to match your physical display setup. Select a display to 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Display Arrangement"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5781,11 +5789,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Select Location"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6106,7 +6114,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Alert Sound"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8540,6 +8548,16 @@ msgstr "Show warning when running a development build of Settings"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Whether Settings should show a warning when running a development build."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/eo.po
+++ b/po/eo.po
@@ -19,9 +19,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:03+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Esperanto (http://www.transifex.com/endless-os/gnome-control-center/language/eo/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,7 +67,7 @@ msgstr "Havas retaliron"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Hejmo"
 
@@ -367,7 +367,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -426,10 +426,6 @@ msgstr "Aktuala fono"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivecoj"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1408,6 +1404,14 @@ msgstr "Speguli"
 msgid "Display Mode"
 msgstr "Reĝimo de ekrano"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1417,6 +1421,10 @@ msgstr "Tiru ekranojn por kongrui vian fizikan ekranaranĝon. Elektu ekranon por
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Aranĝo de ekranoj"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5786,11 +5794,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lingvo;Klavararanĝo;Klavaro;Enigo;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Elekti lokon"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Bone"
 
@@ -6111,7 +6119,7 @@ msgstr "Laŭteco"
 msgid "Alert Sound"
 msgstr "Laŭteco por avertoj"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8545,6 +8553,16 @@ msgstr "Montri averton kiam rulante programistan version de la stircentro"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Ĉu la stircentro devus montri averton kiam rulante programistan version."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/es.po
+++ b/po/es.po
@@ -25,9 +25,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:58+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/endless-os/gnome-control-center/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -73,7 +73,7 @@ msgstr "Tiene acceso a la red"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Domicilio"
 
@@ -373,7 +373,7 @@ msgstr "Seleccionar una imagen"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -432,10 +432,6 @@ msgstr "Fondo actual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Añadir imagen…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Actividades"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1414,6 +1410,14 @@ msgstr "Espejo"
 msgid "Display Mode"
 msgstr "Modo de la pantalla"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Pantalla primaria"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1423,6 +1427,10 @@ msgstr "Arrastre las pantallas para que coincidan con su configuración. Selecci
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Distribución de las pantallas"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5792,11 +5800,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Distribución;Teclado;Entrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Seleccionar ubicación"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Aceptar"
 
@@ -6117,7 +6125,7 @@ msgstr "Volumen"
 msgid "Alert Sound"
 msgstr "Sonido de alerta"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8551,6 +8559,16 @@ msgstr "Mostrar advertencia al ejecutar una versión de desarrollo de Configurac
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Indica si Configuración debe mostrar advertencia al ejecutar una versión de desarrollo de Configuración."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/et.po
+++ b/po/et.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:10+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Estonian (http://www.transifex.com/endless-os/gnome-control-center/language/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -60,7 +60,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Kodukataloog"
 
@@ -360,7 +360,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -419,10 +419,6 @@ msgstr "Praegune taustapilt"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Tegevused"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1401,6 +1397,14 @@ msgstr "Peegeldatud"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1409,6 +1413,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5779,11 +5787,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Keel;Paigutus;Klaviatuur;Sisend;Sisestamine;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Asukoha valimine"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Olgu"
 
@@ -6104,7 +6112,7 @@ msgstr "Helitugevus"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8537,6 +8545,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/eu.po
+++ b/po/eu.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:11+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Basque (http://www.transifex.com/endless-os/gnome-control-center/language/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -60,7 +60,7 @@ msgstr "Sarea atzitu dezake"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Karpeta nagusia"
 
@@ -360,7 +360,7 @@ msgstr "Hautatu argazki bat"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -419,10 +419,6 @@ msgstr "Uneko atzeko planoa"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Gehitu argazkia…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Jarduerak"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1401,6 +1397,14 @@ msgstr "Ispilua"
 msgid "Display Mode"
 msgstr "Bistaratze-modua"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Pantaila nagusia"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1410,6 +1414,10 @@ msgstr "Arrastatu pantailak zure pantaila fisikoaren konfigurazioarekin bat egin
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Pantailen antolaketa"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5779,11 +5787,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Hizkuntza;Diseinua;Teklatua;Sarrera;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Hautatu kokalekua"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Ados"
 
@@ -6104,7 +6112,7 @@ msgstr "Bolumena"
 msgid "Alert Sound"
 msgstr "Alertako soinua"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "% 100"
@@ -8538,6 +8546,16 @@ msgstr "Erakutsi abisu bat ezarpenen garapen-bertsio bat exekutatzean"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Ezarpenek abisu bat erakutsi behar duen ala ez garapen-bertsio bat exekutatzen denean."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/fa.po
+++ b/po/fa.po
@@ -15,9 +15,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:13+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Persian (http://www.transifex.com/endless-os/gnome-control-center/language/fa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -63,7 +63,7 @@ msgstr "دسترسی شبکه دارد"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "منزل"
 
@@ -363,7 +363,7 @@ msgstr "گزینش یک عکس"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -422,10 +422,6 @@ msgstr "تصویر پس‌زمینه کنونی"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "افزودن عکس…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "فعّالیت‌ها"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1404,6 +1400,14 @@ msgstr "آینه"
 msgid "Display Mode"
 msgstr "نوع نمایشگر"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "نمایشگر اصلی"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1413,6 +1417,10 @@ msgstr "نمایشگرها را برای تطبیق با وضعیت واقعی �
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "آرایش نمایشگر"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5782,11 +5790,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "زبان;چیدمان;صفحه‌کلید؛ورودی;Language;Layout;Keyboard;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "گزینش مکان"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_تأیید"
 
@@ -6107,7 +6115,7 @@ msgstr "بلندی صدا"
 msgid "Alert Sound"
 msgstr "صدای هشدار"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "۱۰۰٪"
@@ -8541,6 +8549,16 @@ msgstr "نمایش هشدار هنگام اجرای یک ساخت در حال ت
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "تنظیمات آب‌وهوا باید هنگام اجرای یک ساخت در حال توسعه، هشداری نشان دهد."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:17+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/endless-os/gnome-control-center/language/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr "Verkon käyttö"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Koti"
 
@@ -359,7 +359,7 @@ msgstr "Valitse kuva"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "Nykyinen taustakuva"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Lisää kuva…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Toiminnot"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr "Peili"
 msgid "Display Mode"
 msgstr "Näyttötila"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Ensisijainen näyttö"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1409,6 +1413,10 @@ msgstr "Vedä näytöt vastaamaan näyttöjesi järjestystä. Valitse näyttö m
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Näyttöjen järjestys"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5778,11 +5786,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Kieli;Asettelu;Näppäimistö;Syöte;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Valitse sijainti"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6103,7 +6111,7 @@ msgstr "Äänenvoimakkuus"
 msgid "Alert Sound"
 msgstr "Hälytysääni"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100 %"
@@ -8537,6 +8545,16 @@ msgstr "Näytä varoitus kun käytössä on järjestelmäasetusten kehitysversio
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Tulisiko järjestelmäasetusten näyttää varoitus, kun käytössä on kehitysversio."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/fil.po
+++ b/po/fil.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Filipino (http://www.transifex.com/endless-os/gnome-control-center/language/fil/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/fr.po
+++ b/po/fr.po
@@ -31,9 +31,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:00+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: French (http://www.transifex.com/endless-os/gnome-control-center/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -79,7 +79,7 @@ msgstr "A accès au réseau"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Dossier personnel"
 
@@ -379,7 +379,7 @@ msgstr "Sélectionner une image"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -438,10 +438,6 @@ msgstr "Arrière-plan actuel"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Ajouter une image…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activités"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1420,6 +1416,14 @@ msgstr "Cloner"
 msgid "Display Mode"
 msgstr "Mode d’affichage"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Écran principal"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1429,6 +1433,10 @@ msgstr "Faites glisser les écrans pour correspondre à votre configuration rée
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Disposition des écrans"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5798,11 +5806,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Langue;Disposition;Clavier;Saisie;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Sélectionner un emplacement"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Valider"
 
@@ -6123,7 +6131,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Son d’alerte"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100 %"
@@ -8557,6 +8565,16 @@ msgstr "Afficher un avertissement lors de l’utilisation d’une version de dé
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Indique si Paramètres doit afficher un avertissement lors de l’utilisation d’une version de développement."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/fur.po
+++ b/po/fur.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:58+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Friulian (http://www.transifex.com/endless-os/gnome-control-center/language/fur/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "Al à acès ae rêt"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Cjase"
 
@@ -358,7 +358,7 @@ msgstr "Selezione un imagjin"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Fonts atuâl"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Zonte imagjin…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Ativitâts"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Duplicât"
 msgid "Display Mode"
 msgstr "Modalitât visôr"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Visôr primari"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "Strissine i visôrs par fâ corispuindi la tô configurazion fisiche dai
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Disposizion dai visôrs"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5777,11 +5785,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lenghe;Disposizion;Layout;Tastiere;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Selezione posizion"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6102,7 +6110,7 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr "Sun di avîs"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8536,6 +8544,16 @@ msgstr "Mostre avertiment cuant che si eseguìs une version di svilup di Imposta
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Indiche se Impostazions al à di mostrâ un avertiment cuant che si eseguìs une version di svilup."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/fy.po
+++ b/po/fy.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Western Frisian (http://www.transifex.com/endless-os/gnome-control-center/language/fy/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ga.po
+++ b/po/ga.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Irish (http://www.transifex.com/endless-os/gnome-control-center/language/ga/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Baile"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr "Cúlra reatha"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Gníomhartha"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1398,6 +1394,14 @@ msgstr "Scáthánaigh"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5806,11 +5814,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Teanga;Leagan Amach;Méarchlár;Ionchur;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Roghnaigh Suíomh"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "Tá g_o Maith"
 
@@ -6131,7 +6139,7 @@ msgstr "Airde"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8570,6 +8578,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/gd.po
+++ b/po/gd.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Gaelic, Scottish (http://www.transifex.com/endless-os/gnome-control-center/language/gd/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Dhachaigh"
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "An cùlaibh làithreach"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Gnìomhachdan"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr "Sgàthanaich"
 msgid "Display Mode"
 msgstr "Modh an taisbeanaidh"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1409,6 +1413,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Rian nan uidheaman-taisbeanaidh"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5798,11 +5806,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "cànan;co-dhealbhachd;meur-chlàr;ion-chur;Language;Layout;Keyboard;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Tagh ionad"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Ceart ma-tha"
 
@@ -6123,7 +6131,7 @@ msgstr "Àirde na fuaime"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8560,6 +8568,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/gl.po
+++ b/po/gl.po
@@ -19,9 +19,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:05+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Galician (http://www.transifex.com/endless-os/gnome-control-center/language/gl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,7 +67,7 @@ msgstr "Ten acceso á rede"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Cartafol persoal"
 
@@ -367,7 +367,7 @@ msgstr "Seleccione unha imaxe"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -426,10 +426,6 @@ msgstr "Fondo actual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Engadir imaxe…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Actividades"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1408,6 +1404,14 @@ msgstr "Espello"
 msgid "Display Mode"
 msgstr "Modo de pantalla"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Pantalla principal"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1417,6 +1421,10 @@ msgstr "Arrastre as pantallas para que coincidan coa súa configuración física
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Disposición de pantallas"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5786,11 +5794,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma:Distribución;Teclado;Entrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Seleccionar localización"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Aceptar"
 
@@ -6111,7 +6119,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Son de alerta"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8545,6 +8553,16 @@ msgstr "Mostrar un aviso cando se execute unha construción para desenvolvemento
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Indica se a configuración mostrará un aviso cando se execute unha construción para desenvolvemento."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/gnome-control-center-2.0.pot
+++ b/po/gnome-control-center-2.0.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center-2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -353,7 +353,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270 panels/region/cc-format-chooser.ui:24
 #: panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -411,10 +411,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1385,6 +1381,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1393,6 +1397,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5703,11 +5711,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6026,7 +6034,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8445,6 +8453,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/gu.po
+++ b/po/gu.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:06+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Gujarati (http://www.transifex.com/endless-os/gnome-control-center/language/gu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "ઘર"
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "હાલનાં પાશ્ર્વભાગો"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "પ્રવૃત્તિઓ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr "મિરર"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5778,11 +5786,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ભાષા;લેઆઉટ;કિબોર્ડ;ઇનપુટ;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "સ્થાન પસંદ કરો"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "બરાબર (_O)"
 
@@ -6103,7 +6111,7 @@ msgstr "અવાજ"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8536,6 +8544,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ha.po
+++ b/po/ha.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Hausa (http://www.transifex.com/endless-os/gnome-control-center/language/ha/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/he.po
+++ b/po/he.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:06+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Hebrew (http://www.transifex.com/endless-os/gnome-control-center/language/he/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -60,7 +60,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "בית"
 
@@ -360,7 +360,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -419,10 +419,6 @@ msgstr "הרקע הנוכחי"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "פעילויות"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1401,6 +1397,14 @@ msgstr "שגיאה"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1409,6 +1413,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5799,11 +5807,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "שפה;פריסה;מקלדת;פלט;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "בחירת מיקום"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_אישור"
 
@@ -6124,7 +6132,7 @@ msgstr "עצמת קול"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8561,6 +8569,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/hi.po
+++ b/po/hi.po
@@ -14,9 +14,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:11+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Hindi (http://www.transifex.com/endless-os/gnome-control-center/language/hi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -62,7 +62,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "घर"
 
@@ -362,7 +362,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -421,10 +421,6 @@ msgstr "मौजूदा पृष्ठभूमि"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "क्रियाएँ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1403,6 +1399,14 @@ msgstr "मिरर"
 msgid "Display Mode"
 msgstr "डिस्प्ले मोड"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "प्राथमिक डिस्प्ले"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "प्रदर्शन व्यवस्था"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5781,11 +5789,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "भाषा;लेआउट;कीबोर्ड; इनपुट;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "स्थान चुनें"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ठीक (_O)"
 
@@ -6106,7 +6114,7 @@ msgstr "वॉल्यूम"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8539,6 +8547,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:09+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/endless-os/gnome-control-center/language/hr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr "Ima pristup mreži"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Osobna mapa"
 
@@ -356,7 +356,7 @@ msgstr "Odaberi sliku"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr "Trenutna pozadina"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Dodaj sliku…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivnosti"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1397,6 +1393,14 @@ msgstr "Zrcalo"
 msgid "Display Mode"
 msgstr "Način rada zalona"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Glavni zaslon"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr "Povlačite zaslone kako bi se prilagodili vašim fizičkim postavkama za
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Razmještaj zaslona"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5785,11 +5793,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Jezik;Raspored;Tipkovnica;ulaz;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Odaberi lokaciju"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_U redu"
 
@@ -6110,7 +6118,7 @@ msgstr "Glasnoća zvuka"
 msgid "Alert Sound"
 msgstr "Zvuk upozorenja"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8546,6 +8554,16 @@ msgstr "Prikaži upozorenje kada je pokrenuta razvojna inačica Postavki"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Trebaju li Postavke prikazati upozorenje kada je pokrenuta razvojna inačica."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/hu.po
+++ b/po/hu.po
@@ -24,9 +24,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:07+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Hungarian (http://www.transifex.com/endless-os/gnome-control-center/language/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -72,7 +72,7 @@ msgstr "Van hálózati kapcsolata"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Saját mappa"
 
@@ -372,7 +372,7 @@ msgstr "Fénykép kiválasztása"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -431,10 +431,6 @@ msgstr "Jelenlegi háttér"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Fénykép hozzáadása…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Tevékenységek"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1413,6 +1409,14 @@ msgstr "Tükrözés"
 msgid "Display Mode"
 msgstr "Megjelenítés módja"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Elsődleges kijelző"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1422,6 +1426,10 @@ msgstr "Húzza a kijelzőket, hogy illeszkedjenek a fizikai kijelző beállítá
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Kijelzők elrendezése"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5791,11 +5799,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Nyelv;kiosztás;billentyűzet;bevitel;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Válasszon régiót"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6116,7 +6124,7 @@ msgstr "Hangerő"
 msgid "Alert Sound"
 msgstr "Riasztási hang"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8550,6 +8558,16 @@ msgstr "Figyelmeztetés megjelenítése, ha a Beállítások fejlesztői verzió
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "A Beállítások jelenítsen-e meg figyelmeztetést, ha fejlesztői kiadást használ."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/hy.po
+++ b/po/hy.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Armenian (http://www.transifex.com/endless-os/gnome-control-center/language/hy/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Սեփական տուն"
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ia.po
+++ b/po/ia.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Interlingua (http://www.transifex.com/endless-os/gnome-control-center/language/ia/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activitates"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr "Volumine"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/id.po
+++ b/po/id.po
@@ -21,9 +21,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:55+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/endless-os/gnome-control-center/language/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -69,7 +69,7 @@ msgstr "Memiliki akses jaringan"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Rumah"
 
@@ -369,7 +369,7 @@ msgstr "Pilih gambar"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -428,10 +428,6 @@ msgstr "Latar belakang kini"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Tambah Gambar…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivitas"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1410,6 +1406,14 @@ msgstr "Cermin"
 msgid "Display Mode"
 msgstr "Mode Tampilan"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Tampilan Primer"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1419,6 +1423,10 @@ msgstr "Seret tampilan untuk mencocokkan pengaturan tampilan fisik Anda. Pilih t
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Pengaturan Tampilan"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5778,11 +5786,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Bahasa;Tata Letak;Papan Tik;Masukan;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Pilih Lokasi"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6103,7 +6111,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Suara Waspada"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8535,6 +8543,16 @@ msgstr "Tampilkan peringatan saat menjalankan hasil bangun pengembangan (develop
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Apakah Pengaturan harus menampilkan peringatan saat menjalankan hasil bangun pengembangan (development build)."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ig.po
+++ b/po/ig.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Igbo (http://www.transifex.com/endless-os/gnome-control-center/language/ig/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5764,11 +5772,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6089,7 +6097,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8520,6 +8528,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/io.po
+++ b/po/io.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Ido (http://www.transifex.com/endless-os/gnome-control-center/language/io/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/is.po
+++ b/po/is.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:07+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Icelandic (http://www.transifex.com/endless-os/gnome-control-center/language/is/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "Er með aðgang að netkerfi"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Heim"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Núverandi bakgrunnur"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Virkni"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Spegla"
 msgid "Display Mode"
 msgstr "Birtingarhamur"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Aðalskjár"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "Dragðu skjái til svo þeir samsvari uppsetningunni hjá þér. Veldu s
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Fyrirkomulag á skjám"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5777,11 +5785,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Tungumál;Framsetning;Lyklaborð;Inntak;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Veldu staðsetningu"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "Í _lagi"
 
@@ -6102,7 +6110,7 @@ msgstr "Hljóðstyrkur"
 msgid "Alert Sound"
 msgstr "Viðvörunarhljóð"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8536,6 +8544,16 @@ msgstr "Birta aðvörun þegar verið er að keyra þróunarútgáfu af Settings
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Hvort Settings eigi að birta aðvörun þegar verið er að keyra þróunarútgáfu."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/it.po
+++ b/po/it.po
@@ -14,9 +14,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:04+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Italian (http://www.transifex.com/endless-os/gnome-control-center/language/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -62,7 +62,7 @@ msgstr "Ha accesso alla rete"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Home"
 
@@ -362,7 +362,7 @@ msgstr "Seleziona un'immagine"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -421,10 +421,6 @@ msgstr "Sfondo attuale"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Aggiungi immagine…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Attività"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1403,6 +1399,14 @@ msgstr "Duplicato"
 msgid "Display Mode"
 msgstr "Modalità schermo"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Schermo primario"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr "Trascinare gli schermi per organizzarli in base alla propria configurazi
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Disposizione schermo"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5781,11 +5789,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lingua;Disposizione;Layout;Tastiera;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Seleziona posizione"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6106,7 +6114,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Suono di avviso"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8540,6 +8548,16 @@ msgstr "Mostra avviso quando si esegue una versione di sviluppo"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Indica se il programma debba mostrare un avviso quando viene eseguita una versione di sviluppo."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ja.po
+++ b/po/ja.po
@@ -28,9 +28,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:16+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Japanese (http://www.transifex.com/endless-os/gnome-control-center/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -76,7 +76,7 @@ msgstr "ネットワークアクセス"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "ホーム"
 
@@ -376,7 +376,7 @@ msgstr "画像の選択"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -435,10 +435,6 @@ msgstr "現在の背景"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "写真の追加…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "アクティビティ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1417,6 +1413,14 @@ msgstr "ミラー"
 msgid "Display Mode"
 msgstr "ディスプレイモード"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1426,6 +1430,10 @@ msgstr "実際の配置に合わせてディスプレイをドラッグしてく
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "ディスプレイの配置"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5785,11 +5793,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;言語;レイアウト;キーボード;入力;インプット;Region;地域;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "場所の選択"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "OK(_O)"
 
@@ -6110,7 +6118,7 @@ msgstr "音量"
 msgid "Alert Sound"
 msgstr "警告音"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8541,6 +8549,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ka.po
+++ b/po/ka.po
@@ -15,9 +15,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Georgian (http://www.transifex.com/endless-os/gnome-control-center/language/ka/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -63,7 +63,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "სახლი"
 
@@ -363,7 +363,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -421,10 +421,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1404,6 +1400,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5782,11 +5790,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6107,7 +6115,7 @@ msgstr "ხმის სიმაღლე"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8540,6 +8548,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/kab.po
+++ b/po/kab.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Kabyle (http://www.transifex.com/endless-os/gnome-control-center/language/kab/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/kk.po
+++ b/po/kk.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Kazakh (http://www.transifex.com/endless-os/gnome-control-center/language/kk/)\n"
 "MIME-Version: 1.0\n"
@@ -56,7 +56,7 @@ msgstr "Желіге қатынау құқығы бар"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Үй"
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr "Ағымдағы фон"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Көрініс"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1397,6 +1393,14 @@ msgstr "Айналы"
 msgid "Display Mode"
 msgstr "Экран режимі"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Біріншілік экран"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr "Экрандары физикалық орналасуына сәйке�
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Экрандар орналасуы"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5775,11 +5783,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;Тіл;Жайма;Пернетақта;Енгізу;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Орналасуды таңдау"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_ОК"
 
@@ -6100,7 +6108,7 @@ msgstr "Том"
 msgid "Alert Sound"
 msgstr "Хабарлама дыбысы"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8534,6 +8542,16 @@ msgstr "Баптаулардың әзірлеушілер нұсқасын ор�
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Баптаулардың әзірлеушілер нұсқасын орындау кезінде ескертуді көрсету керек пе."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/km.po
+++ b/po/km.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Khmer (http://www.transifex.com/endless-os/gnome-control-center/language/km/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr "ផ្ទៃខាងក្រោយ​បច្ចុប្បន្ន
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "សកម្មភាព"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1398,6 +1394,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5766,11 +5774,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6091,7 +6099,7 @@ msgstr "កម្រិត​សំឡេង"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "១០០%"
@@ -8522,6 +8530,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/kn.po
+++ b/po/kn.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:03+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Kannada (http://www.transifex.com/endless-os/gnome-control-center/language/kn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "ನೆಲೆ"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr "ಈಗಿನ ಹಿನ್ನಲೆ ಚಿತ್ರ"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "ಚಟುವಟಿಕೆಗಳು"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1398,6 +1394,14 @@ msgstr "ಬಿಂಬ"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5776,11 +5784,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ಭಾಷೆ;ವಿನ್ಯಾಸ;ಕೀಲಿಮಣೆ;ಇನ್‌ಪುಟ್;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "ಸ್ಥಳವನ್ನು ಆರಿಸಿ"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ಸರಿ (_O)"
 
@@ -6101,7 +6109,7 @@ msgstr "ಪರಿಮಾಣ"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8534,6 +8542,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ko.po
+++ b/po/ko.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:00+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Korean (http://www.transifex.com/endless-os/gnome-control-center/language/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "네트워크 접근 가능"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "내 폴더"
 
@@ -358,7 +358,7 @@ msgstr "사진을 고르십시오"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "현재 배경"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "사진 추가…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "현재 활동"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "동일 화면"
 msgid "Display Mode"
 msgstr "디스플레이 모드"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "주요 디스플레이"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "물리적인 디스플레이 설정에 맞는 디스플레이를 끌어 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "디스플레이 배치"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5767,11 +5775,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;언어;Layout;배치;Keyboard;키보드;Input;입력;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "위치 선택"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "확인(_O)"
 
@@ -6092,7 +6100,7 @@ msgstr "음량"
 msgid "Alert Sound"
 msgstr "경보음"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8524,6 +8532,16 @@ msgstr "설정의 개발 빌드를 실행할 때 경고 표시"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "설정에서 개발 버전을 실행할 때 경고를 표시할지 여부."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ks.po
+++ b/po/ks.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Kashmiri (http://www.transifex.com/endless-os/gnome-control-center/language/ks/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ku.po
+++ b/po/ku.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Kurdish (http://www.transifex.com/endless-os/gnome-control-center/language/ku/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1399,6 +1395,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1407,6 +1411,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5777,11 +5785,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6102,7 +6110,7 @@ msgstr "Deng"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ky.po
+++ b/po/ky.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Vicki Niu <vicki@endlessm.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Kyrgyz (http://www.transifex.com/endless-os/gnome-control-center/language/ky/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Башы"
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr "Учурдагы фон"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Сереп"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5765,11 +5773,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6090,7 +6098,7 @@ msgstr "Катуулук"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8521,6 +8529,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/la.po
+++ b/po/la.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Latin (http://www.transifex.com/endless-os/gnome-control-center/language/la/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/li.po
+++ b/po/li.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Limburgian (http://www.transifex.com/endless-os/gnome-control-center/language/li/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ln.po
+++ b/po/ln.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Lingala (http://www.transifex.com/endless-os/gnome-control-center/language/ln/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Yambo"
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_IYO"
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/lt.po
+++ b/po/lt.po
@@ -16,9 +16,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:16+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/endless-os/gnome-control-center/language/lt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,7 +64,7 @@ msgstr "Turi tinklo prieigą"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Namų aplankas"
 
@@ -364,7 +364,7 @@ msgstr "Pasirinkite paveikslėlį"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -423,10 +423,6 @@ msgstr "Dabartinis fonas"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Pridėti paveikslėlį…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Veiklos"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1405,6 +1401,14 @@ msgstr "Veidrodis"
 msgid "Display Mode"
 msgstr "Vaizduoklio veiksena"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Pagrindinis vaizduoklis"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1414,6 +1418,10 @@ msgstr "Tempkite vaizduoklius, kad jie atitiktų jūsų fizinį išdėstymą. Pa
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Vaizduoklių išdėstymas"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5803,11 +5811,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Kalba;Išdėstymas;Klaviatūra;Įvestis;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Pasirinkite vietą"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Gerai"
 
@@ -6128,7 +6136,7 @@ msgstr "Garsumas"
 msgid "Alert Sound"
 msgstr "Įspėjimų garsumas"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8566,6 +8574,16 @@ msgstr "Rodyti įspėjimą vykdant Nustatymų kuriamą versiją"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Ar Nustatymai turėtų rodyti įspėjimą vykdant kuriamą versiją."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/lv.po
+++ b/po/lv.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Latvian (http://www.transifex.com/endless-os/gnome-control-center/language/lv/)\n"
 "MIME-Version: 1.0\n"
@@ -61,7 +61,7 @@ msgstr "Ir piekļuve tīklam"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Mājas"
 
@@ -361,7 +361,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -420,10 +420,6 @@ msgstr "Pašreizējais fons"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivitātes"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1402,6 +1398,14 @@ msgstr "Dublēt"
 msgid "Display Mode"
 msgstr "Displeja režīms"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primārais ekrāns"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1411,6 +1415,10 @@ msgstr "Velciet displejus, lai tie atbilstu monitoru fiziskajam novietojumam. Iz
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Displeju izkārtojums"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5790,11 +5798,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Valoda;Izkārtojums;Tastatūra;Ievade;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Izvēlieties vietu"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Labi"
 
@@ -6115,7 +6123,7 @@ msgstr "Skaļums"
 msgid "Alert Sound"
 msgstr "Trauksmes skaņa"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8551,6 +8559,16 @@ msgstr "Rādīt brīdinājumus, kad palaiž “Iestatījumu” izstrādes būvē
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Vai “Iestatījumiem” vajadzētu rādīt brīdinājumu, kad palaiž izstrādes būvējumu."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/mai.po
+++ b/po/mai.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Maithili (http://www.transifex.com/endless-os/gnome-control-center/language/mai/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "घर"
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/mg.po
+++ b/po/mg.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Malagasy (http://www.transifex.com/endless-os/gnome-control-center/language/mg/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr "Fanamafisam-peo"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/mi.po
+++ b/po/mi.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Maori (http://www.transifex.com/endless-os/gnome-control-center/language/mi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/mk.po
+++ b/po/mk.po
@@ -16,9 +16,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Macedonian (http://www.transifex.com/endless-os/gnome-control-center/language/mk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,7 +64,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Дома"
 
@@ -364,7 +364,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -423,10 +423,6 @@ msgstr "Тековна позадина"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Активности"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1405,6 +1401,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1413,6 +1417,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5783,11 +5791,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6108,7 +6116,7 @@ msgstr "Гласност"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8541,6 +8549,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ml.po
+++ b/po/ml.po
@@ -19,9 +19,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:16+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Malayalam (http://www.transifex.com/endless-os/gnome-control-center/language/ml/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,7 +67,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "തട്ടകം"
 
@@ -367,7 +367,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -426,10 +426,6 @@ msgstr "നിലവിലുള്ള പശ്ചാതലം"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "പ്രവര്‍ത്തനങ്ങള്‍"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1408,6 +1404,14 @@ msgstr "മിറര്‍"
 msgid "Display Mode"
 msgstr "പ്രദര്‍ശന രീതി"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "പ്രധാന ഡിസ്പ്ലേ"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1417,6 +1421,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "പ്രദര്‍ശന സജ്ജികരണം"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5786,11 +5794,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "സ്ഥലം തെരഞ്ഞെടുക്കുക"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ശരി"
 
@@ -6111,7 +6119,7 @@ msgstr "ഒച്ച"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8544,6 +8552,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/mn.po
+++ b/po/mn.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Mongolian (http://www.transifex.com/endless-os/gnome-control-center/language/mn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1399,6 +1395,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1407,6 +1411,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5777,11 +5785,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6102,7 +6110,7 @@ msgstr "Дуу"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/mr.po
+++ b/po/mr.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:15+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Marathi (http://www.transifex.com/endless-os/gnome-control-center/language/mr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "गृह"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr "सध्याची पार्श्वभूमी"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "क्रिया"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1398,6 +1394,14 @@ msgstr "मिरर"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5776,11 +5784,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "भाषा;मांडणी;कळफलक;इंपुट;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "ठिकाण पसंत करा"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ठीक आहे (_O)"
 
@@ -6101,7 +6109,7 @@ msgstr "आवाज"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8534,6 +8542,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ms.po
+++ b/po/ms.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:15+0000\n"
-"Last-Translator: abuyop <abuyop@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Malay (http://www.transifex.com/endless-os/gnome-control-center/language/ms/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "Mempunyai capaian rangkaian"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Rumah"
 
@@ -286,7 +286,7 @@ msgstr "Buka dalam Pusat Apl"
 
 #: panels/applications/cc-applications-panel.ui:463 shell/cc-panel-list.ui:190
 msgid "No results found"
-msgstr ""
+msgstr "Tiada keputusan ditemui"
 
 #: panels/applications/cc-applications-panel.ui:474
 #: panels/keyboard/cc-keyboard-panel.ui:157 shell/cc-panel-list.ui:201
@@ -342,7 +342,7 @@ msgstr "Kertas Dinding"
 
 #: panels/background/cc-background-chooser.c:349
 msgid "Select a picture"
-msgstr ""
+msgstr "Pilih satu gambar"
 
 #: panels/background/cc-background-chooser.c:352
 #: panels/color/cc-color-panel.c:241 panels/color/cc-color-panel.c:894
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -381,19 +381,19 @@ msgstr "_Buka"
 
 #: panels/background/cc-background-chooser.ui:104
 msgid "Set Background and Lock Screen"
-msgstr ""
+msgstr "Tetapkan Latar Belakang dan Skrin Kunci"
 
 #: panels/background/cc-background-chooser.ui:114
 msgid "Set Background"
-msgstr ""
+msgstr "Tetapkan Latar Belakang"
 
 #: panels/background/cc-background-chooser.ui:121
 msgid "Set Lock Screen"
-msgstr ""
+msgstr "Tetapkan Skrin Kunci"
 
 #: panels/background/cc-background-chooser.ui:143
 msgid "Remove Background"
-msgstr ""
+msgstr "Buang Latar Belakang"
 
 #: panels/background/cc-background-item.c:140
 msgid "multiple sizes"
@@ -416,11 +416,7 @@ msgstr "Latar belakang semasa"
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktiviti"
+msgstr "Tambah Gambar..."
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Cermin"
 msgid "Display Mode"
 msgstr "Mod Paparan"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "Seret paparan untuk dipadankan dengan persediaan paparan fizikal anda. P
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Penyusunan Paparan"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -1475,11 +1483,11 @@ msgstr "Skala"
 
 #: panels/display/cc-night-light-page.c:622
 msgid "More Warm"
-msgstr ""
+msgstr "Lebih Suam"
 
 #: panels/display/cc-night-light-page.c:634
 msgid "Less Warm"
-msgstr ""
+msgstr "Kurang Suam"
 
 #. This cancels the redshift inhibit.
 #: panels/display/cc-night-light-page.ui:28
@@ -1507,7 +1515,7 @@ msgstr "Matahari Terbit hingga Matahari Terbenam"
 
 #: panels/display/cc-night-light-page.ui:137
 msgid "Manual Schedule"
-msgstr ""
+msgstr "Jadual Manual"
 
 #: panels/display/cc-night-light-page.ui:148
 #: panels/region/cc-format-chooser.ui:154
@@ -2136,7 +2144,7 @@ msgstr "Pintasan;RuangKerja;Tetingkap;SaizSemula;Zum;BezaJelas;Input;Sumber;Kunc
 #: panels/keyboard/shortcut-editor.ui:68
 #: panels/keyboard/shortcut-editor.ui:318
 msgid "Press Esc to cancel or Backspace to disable the keyboard shortcut."
-msgstr ""
+msgstr "Tekan Esc untuk batal atau Backspace untuk lumpuhkan pintasan papan kekunci."
 
 #: panels/keyboard/shortcut-editor.ui:156 panels/printers/details-dialog.ui:38
 msgid "Name"
@@ -2330,7 +2338,7 @@ msgstr "Pengurus Rangkaian perlu dijalankan."
 
 #: panels/network/cc-network-panel.ui:102
 msgid "Other Devices"
-msgstr ""
+msgstr "Lain-Lain Peranti"
 
 #: panels/network/cc-network-panel.ui:143
 #: panels/network/connection-editor/net-connection-editor.c:581
@@ -2430,26 +2438,26 @@ msgstr "Keselamatan"
 
 #: panels/network/connection-editor/ce-page.c:396
 msgid "Preserve"
-msgstr ""
+msgstr "Kekal"
 
 #: panels/network/connection-editor/ce-page.c:397
 msgid "Permanent"
-msgstr ""
+msgstr "Kekal"
 
 #: panels/network/connection-editor/ce-page.c:398
 msgid "Random"
-msgstr ""
+msgstr "Rawak"
 
 #: panels/network/connection-editor/ce-page.c:399
 msgid "Stable"
-msgstr ""
+msgstr "Stabil"
 
 #: panels/network/connection-editor/ce-page.c:403
 msgid ""
 "The MAC address entered here will be used as hardware address for the "
 "network device this connection is activated on. This feature is known as MAC"
 " cloning or spoofing. Example: 00:11:22:33:44:55"
-msgstr ""
+msgstr "Alamat MAC yang dimasukkan di sini akan digunakan sebagai alamat perkakasan bagi peranti rangkaian yang mana sambungannya aktif. Fitur ini dikenali sebagai pengklonan MAC atau perdayaan. Contoh: 00:11:22:33:44:55"
 
 #: panels/network/connection-editor/ce-page.c:538
 msgid "automatic"
@@ -2942,7 +2950,7 @@ msgstr "network-workgroup"
 #. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-network-panel.desktop.in.in:18
 msgid "Network;IP;LAN;Proxy;WAN;Broadband;Modem;Bluetooth;vpn;DNS;"
-msgstr ""
+msgstr "Rangkaian;IP;LAN;Proksi;WAN;JalurLebar;Modem;Bluetooth;vpn;DNS;"
 
 #: panels/network/gnome-wifi-panel.desktop.in.in:4
 msgid "Control how you connect to Wi-Fi networks"
@@ -2958,7 +2966,7 @@ msgstr "network-wireless"
 #. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/network/gnome-wifi-panel.desktop.in.in:18
 msgid "Network;Wireless;Wi-Fi;Wifi;IP;LAN;Broadband;DNS;Hotspot;"
-msgstr ""
+msgstr "Rangkaian;TanpaWayar;Wi-Fi;Wifi;IP;LAN;JalurLebar;DNS;KawasanKhas;"
 
 #: panels/network/net-device-ethernet.c:123
 #: panels/network/net-device-wifi.c:399
@@ -4287,23 +4295,23 @@ msgstr "Penjimatan Kuasa"
 
 #: panels/power/cc-power-panel.c:1860
 msgid "_Screen Brightness"
-msgstr ""
+msgstr "Kecerahan _Skrin"
 
 #: panels/power/cc-power-panel.c:1881
 msgid "Automatic Brightness"
-msgstr ""
+msgstr "Kecerahan Automatik"
 
 #: panels/power/cc-power-panel.c:1894
 msgid "_Keyboard Brightness"
-msgstr ""
+msgstr "Kecerahan Papan _Kekunci"
 
 #: panels/power/cc-power-panel.c:1905
 msgid "_Dim Screen When Inactive"
-msgstr ""
+msgstr "Ma_lapkan Skrin Ketika Tidak Aktif"
 
 #: panels/power/cc-power-panel.c:1923
 msgid "_Blank Screen"
-msgstr ""
+msgstr "Skrin _Gelap"
 
 #: panels/power/cc-power-panel.c:1946
 msgid "_Wi-Fi"
@@ -4315,7 +4323,7 @@ msgstr "Wi-Fi boleh dimatikan untuk menjimatkan tenaga."
 
 #: panels/power/cc-power-panel.c:1963
 msgid "_Mobile Broadband"
-msgstr ""
+msgstr "Jalur Lebar _Mudah Alih"
 
 #: panels/power/cc-power-panel.c:1964
 msgid "Mobile broadband (LTE, 4G, 3G, etc.) can be turned off to save power."
@@ -4360,7 +4368,7 @@ msgstr "Butang Tangguh & Kuasa"
 
 #: panels/power/cc-power-panel.c:2307
 msgid "_Automatic Suspend"
-msgstr ""
+msgstr "Tangguh _Automatik"
 
 #: panels/power/cc-power-panel.c:2308
 msgid "Automatic suspend"
@@ -4368,7 +4376,7 @@ msgstr "Tangguh automatik"
 
 #: panels/power/cc-power-panel.c:2365
 msgid "Po_wer Button Action"
-msgstr ""
+msgstr "Tindakan Butang K_uasa"
 
 #. Translators: Option for "Delay" in "Automatic suspend" dialog.
 #: panels/power/cc-power-panel.ui:13
@@ -5508,7 +5516,7 @@ msgstr "Kunci skrin _selepas gelap dalam tempoh"
 
 #: panels/privacy/cc-privacy-panel.ui:506
 msgid "Lock Screen _Notifications"
-msgstr ""
+msgstr "_Pemberitahuan Skrin Kunci"
 
 #: panels/privacy/cc-privacy-panel.ui:566
 msgid ""
@@ -5767,11 +5775,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Bahasa;Bentangan;PapanKekunci;Input;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Select Location"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -5791,7 +5799,7 @@ msgstr "Bergerak ke Bawah"
 msgid ""
 "Control which search results are shown in the Activities Overview. The order"
 " of search results can also be changed by moving rows in the list."
-msgstr ""
+msgstr "Tentukan keputusan gelintar manakah akan dipaparkan dalam Selayang Pandang Aktiviti/. Tetib keputusan gelintar juga diubah fengan menggerakkan baris-baris di dalam senarai"
 
 #: panels/search/cc-search-panel.ui:60
 #: panels/search/search-locations-dialog.ui:9
@@ -5821,7 +5829,7 @@ msgstr "Gelintar;Cari;Indeks;Sembunyi;Kerahsiaan;Keputusan;"
 msgid ""
 "Folders which are searched by system applications, such as Files, Photos and"
 " Videos."
-msgstr ""
+msgstr "Folder-folder yang digelintar oleh aplikasi-aplikasi sistem, seperti Fail, Foto dan Video."
 
 #: panels/search/search-locations-dialog.ui:52
 msgid "Places"
@@ -5843,17 +5851,17 @@ msgstr "Tiada rangkaian terpilih untuk perkongsian"
 #: panels/sharing/cc-sharing-panel.c:320
 msgctxt "service is enabled"
 msgid "On"
-msgstr "Buka"
+msgstr "Hidup"
 
 #: panels/sharing/cc-sharing-panel.c:322 panels/sharing/cc-sharing-panel.c:349
 msgctxt "service is disabled"
 msgid "Off"
-msgstr "Tutup"
+msgstr "Mati"
 
 #: panels/sharing/cc-sharing-panel.c:352
 msgctxt "service is enabled"
 msgid "Enabled"
-msgstr "Dibolehkan"
+msgstr "Dibenarkan"
 
 #: panels/sharing/cc-sharing-panel.c:355
 msgctxt "service is active"
@@ -5862,7 +5870,7 @@ msgstr "Aktif"
 
 #: panels/sharing/cc-sharing-panel.c:425
 msgid "Choose a Folder"
-msgstr "Pilih Folder"
+msgstr "Pilih satu Folder"
 
 #: panels/sharing/cc-sharing-panel.c:726
 #, c-format
@@ -6092,7 +6100,7 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr "Bunyi Amaran"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -6116,7 +6124,7 @@ msgstr "multimedia-volume-control"
 #: panels/sound/gnome-sound-panel.desktop.in.in:19
 msgid ""
 "Card;Microphone;Volume;Fade;Balance;Bluetooth;Headset;Audio;Output;Input;"
-msgstr ""
+msgstr "Kad;Mikrofon;Volum;Resap;Imbangan;Bluetooth;SetKepala;Audio;Output;Input;"
 
 #: panels/thunderbolt/cc-bolt-device-dialog.c:94
 #: panels/thunderbolt/cc-bolt-device-entry.c:125
@@ -6162,7 +6170,7 @@ msgstr "Bersambung & Mendapat Izin"
 #: panels/thunderbolt/cc-bolt-device-entry.c:152
 msgctxt "Thunderbolt Device Status"
 msgid "Unknown"
-msgstr "Entah"
+msgstr "Tidak Diketahui"
 
 #. Translators: The time point the device was authorized.
 #: panels/thunderbolt/cc-bolt-device-dialog.c:177
@@ -6298,7 +6306,7 @@ msgstr "Thunderbolt;"
 #: panels/universal-access/cc-ua-panel.c:497
 msgctxt "cursor size"
 msgid "Default"
-msgstr "Default"
+msgstr "Lalai"
 
 #: panels/universal-access/cc-ua-panel.c:500
 msgctxt "cursor size"
@@ -6460,11 +6468,11 @@ msgstr "Kekunci Ulangan"
 
 #: panels/universal-access/cc-ua-panel.ui:1453
 msgid "Key presses repeat when key is held down."
-msgstr ""
+msgstr "Ketikan kekunci diulang jika kekunci ditahan."
 
 #: panels/universal-access/cc-ua-panel.ui:1533
 msgid "Repeat keys delay"
-msgstr ""
+msgstr "Lengah kekunci-kekunci ulang"
 
 #: panels/universal-access/cc-ua-panel.ui:1581
 #: panels/universal-access/cc-ua-panel.ui:1716
@@ -6473,53 +6481,53 @@ msgstr "Kelajuan"
 
 #: panels/universal-access/cc-ua-panel.ui:1620
 msgid "Repeat keys speed"
-msgstr "Ulangan kelajuan kekunci"
+msgstr "Kelajuan kekunci-kekunci ulang"
 
 #: panels/universal-access/cc-ua-panel.ui:1644
 msgid "Cursor Blinking"
-msgstr "Kerdipan Kursor"
+msgstr "Kerlipan Kursor"
 
 #: panels/universal-access/cc-ua-panel.ui:1674
 msgid "Cursor blinks in text fields."
-msgstr ""
+msgstr "Kelipan kursor dalam medan-medan teks."
 
 #: panels/universal-access/cc-ua-panel.ui:1753
 msgid "Cursor blinking speed"
-msgstr ""
+msgstr "Kelajuan kerlipan kursor"
 
 #: panels/universal-access/cc-ua-panel.ui:1789
 msgid "Typing Assist"
-msgstr ""
+msgstr "Bantuan Menaip"
 
 #: panels/universal-access/cc-ua-panel.ui:1828
 msgid "_Sticky Keys"
-msgstr ""
+msgstr "Kekunci-Kekunci _Lekat"
 
 #: panels/universal-access/cc-ua-panel.ui:1845
 msgid "Treats a sequence of modifier keys as a key combination"
-msgstr ""
+msgstr "Anggap jujukan kekunci-kekunci pengubahsuai sebagai satu gabungan kekunci"
 
 #: panels/universal-access/cc-ua-panel.ui:1869
 msgid "_Disable if two keys are pressed together"
-msgstr ""
+msgstr "_Lumpuhkan sekiranya dua kekunci ditekan serentak"
 
 #: panels/universal-access/cc-ua-panel.ui:1887
 msgid "Beep when a _modifier key is pressed"
-msgstr ""
+msgstr "Bunyikan bip ketika satu kekunci peng_ubahsuai ditekan"
 
 #: panels/universal-access/cc-ua-panel.ui:1935
 msgid "S_low Keys"
-msgstr ""
+msgstr "Kekunci-Kekunci _Lambat"
 
 #: panels/universal-access/cc-ua-panel.ui:1952
 msgid "Puts a delay between when a key is pressed and when it is accepted"
-msgstr ""
+msgstr "Letak lengah ketika satu kekunci ditekan dan kemudian ia diterima"
 
 #: panels/universal-access/cc-ua-panel.ui:1985
 #: panels/universal-access/cc-ua-panel.ui:2198
 #: panels/universal-access/cc-ua-panel.ui:2535
 msgid "A_cceptance delay:"
-msgstr ""
+msgstr "Lengah pe_nerimaan:"
 
 #: panels/universal-access/cc-ua-panel.ui:2007
 msgctxt "slow keys delay"
@@ -6528,7 +6536,7 @@ msgstr "Pendek"
 
 #: panels/universal-access/cc-ua-panel.ui:2026
 msgid "Slow keys typing delay"
-msgstr ""
+msgstr "Tunjuk lengah menaip kekunci-kekunci"
 
 #: panels/universal-access/cc-ua-panel.ui:2041
 msgctxt "slow keys delay"
@@ -6537,24 +6545,24 @@ msgstr "Panjang"
 
 #: panels/universal-access/cc-ua-panel.ui:2068
 msgid "Beep when a key is pr_essed"
-msgstr ""
+msgstr "Bunyi bip bila satu kekunci di t_ekan"
 
 #: panels/universal-access/cc-ua-panel.ui:2085
 msgid "Beep when a key is _accepted"
-msgstr ""
+msgstr "Bunyi bip bila satu kekunci di terim_a"
 
 #: panels/universal-access/cc-ua-panel.ui:2102
 #: panels/universal-access/cc-ua-panel.ui:2281
 msgid "Beep when a key is _rejected"
-msgstr ""
+msgstr "Bunyi bip bila satu kekunci di _tolak"
 
 #: panels/universal-access/cc-ua-panel.ui:2148
 msgid "_Bounce Keys"
-msgstr ""
+msgstr "Kekunci-Kekunci _Lantun"
 
 #: panels/universal-access/cc-ua-panel.ui:2165
 msgid "Ignores fast duplicate keypresses"
-msgstr ""
+msgstr "Abai ketukan kekunci pendua pantas"
 
 #: panels/universal-access/cc-ua-panel.ui:2220
 msgctxt "bounce keys delay"
@@ -6563,7 +6571,7 @@ msgstr "Pendek"
 
 #: panels/universal-access/cc-ua-panel.ui:2239
 msgid "Bounce keys typing delay"
-msgstr ""
+msgstr "Lengah menaip kekunci-kekunci lantun"
 
 #: panels/universal-access/cc-ua-panel.ui:2254
 msgctxt "bounce keys delay"
@@ -6572,23 +6580,23 @@ msgstr "Panjang"
 
 #: panels/universal-access/cc-ua-panel.ui:2367
 msgid "_Enable by Keyboard"
-msgstr ""
+msgstr "B_enarkan melalui Papan Kekunci"
 
 #: panels/universal-access/cc-ua-panel.ui:2384
 msgid "Turn accessibility features on and off using the keyboard"
-msgstr ""
+msgstr "Hidup atau matikan fitur-fitur kebolehcapaian melalui papan kekunci"
 
 #: panels/universal-access/cc-ua-panel.ui:2448
 msgid "Click Assist"
-msgstr ""
+msgstr "Bantuan Klik"
 
 #: panels/universal-access/cc-ua-panel.ui:2484
 msgid "_Simulated Secondary Click"
-msgstr ""
+msgstr "Klik Sekunder _Bersimulasi"
 
 #: panels/universal-access/cc-ua-panel.ui:2502
 msgid "Trigger a secondary click by holding down the primary button"
-msgstr ""
+msgstr "Picu satu klik sekunder dengan menahan butang utama"
 
 #: panels/universal-access/cc-ua-panel.ui:2556
 msgctxt "secondary click"
@@ -6597,7 +6605,7 @@ msgstr "Pendek"
 
 #: panels/universal-access/cc-ua-panel.ui:2575
 msgid "Secondary click delay"
-msgstr ""
+msgstr "Lengah klik sekunder"
 
 #: panels/universal-access/cc-ua-panel.ui:2590
 msgctxt "secondary click delay"
@@ -6606,15 +6614,15 @@ msgstr "Panjang"
 
 #: panels/universal-access/cc-ua-panel.ui:2647
 msgid "_Hover Click"
-msgstr ""
+msgstr "Klik _Apung"
 
 #: panels/universal-access/cc-ua-panel.ui:2665
 msgid "Trigger a click when the pointer hovers"
-msgstr ""
+msgstr "Picu satu klik ketika penuding berada di atasnya"
 
 #: panels/universal-access/cc-ua-panel.ui:2698
 msgid "D_elay:"
-msgstr "P_enangguhan:"
+msgstr "L_engah:"
 
 #: panels/universal-access/cc-ua-panel.ui:2720
 msgctxt "dwell click delay"
@@ -6628,7 +6636,7 @@ msgstr "Panjang"
 
 #: panels/universal-access/cc-ua-panel.ui:2787
 msgid "Motion _threshold:"
-msgstr ""
+msgstr "_Ambang gerakan:"
 
 #: panels/universal-access/cc-ua-panel.ui:2809
 msgctxt "dwell click threshold"
@@ -6642,13 +6650,13 @@ msgstr "Besar"
 
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:4
 msgid "Make it easier to see, hear, type, point and click"
-msgstr ""
+msgstr "Jadikannya lebih mudah dilihat, dengar, taip, tuju dan klik"
 
 #. Translators: Do NOT translate or transliterate this text (this is an icon
 #. file name)!
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:7
 msgid "preferences-desktop-accessibility"
-msgstr ""
+msgstr "preferences-desktop-accessibility"
 
 #. Translators: Search terms to find the Universal Access panel. Do NOT
 #. translate or localize the semicolons! The list MUST also end with a
@@ -6656,7 +6664,7 @@ msgstr ""
 #: panels/universal-access/gnome-universal-access-panel.desktop.in.in:18
 msgid ""
 "Keyboard;Mouse;a11y;Accessibility;Contrast;Cursor;Sound;Zoom;Screen;Reader;big;high;large;text;font;size;AccessX;Sticky;Keys;Slow;Bounce;Mouse;Double;click;Delay;Speed;Assist;Repeat;Blink;visual;hearing;audio;typing;"
-msgstr ""
+msgstr "PapanKekunci;Tetikus;a11y;Kebolehcapaian;BezaJelas;Kursor;Bunyi;Zum;Skrin;Pembaca;besar;tinggi;lebihbesar;teks;fon;saiz;AccessX;Lekat;Kekunci;Lambat;Lantun;Tetikus;Dwi;klik;Lengah;Kelajuan;Bantuan;Ulang;Kelip;visual;pendengaran;audio;menaip;"
 
 #: panels/universal-access/zoom-options.c:305
 msgctxt "Distance"
@@ -6689,19 +6697,19 @@ msgstr "Skrin Penuh"
 
 #: panels/universal-access/zoom-options.ui:53
 msgid "Top Half"
-msgstr "Separuh Keatas"
+msgstr "Separa Atas"
 
 #: panels/universal-access/zoom-options.ui:58
 msgid "Bottom Half"
-msgstr ""
+msgstr "Separa Bawah"
 
 #: panels/universal-access/zoom-options.ui:63
 msgid "Left Half"
-msgstr "Separuh Kekiri"
+msgstr "Separa Kiri"
 
 #: panels/universal-access/zoom-options.ui:68
 msgid "Right Half"
-msgstr "Separuh Kekanan"
+msgstr "Separa Kanan"
 
 #: panels/universal-access/zoom-options.ui:78
 msgid "Zoom Options"
@@ -6709,78 +6717,78 @@ msgstr "Pilihan Zum"
 
 #: panels/universal-access/zoom-options.ui:185
 msgid "_Magnification:"
-msgstr ""
+msgstr "Pe_mbesaran:"
 
 #: panels/universal-access/zoom-options.ui:249
 msgid "_Follow mouse cursor"
-msgstr ""
+msgstr "_Ikut kursor tetikus"
 
 #: panels/universal-access/zoom-options.ui:269
 msgid "_Screen part:"
-msgstr ""
+msgstr "Bahagian _skrin:"
 
 #: panels/universal-access/zoom-options.ui:331
 msgid "Magnifier _extends outside of screen"
-msgstr ""
+msgstr "Pembesar m_elangkaui luar skrin"
 
 #: panels/universal-access/zoom-options.ui:350
 msgid "_Keep magnifier cursor centered"
-msgstr ""
+msgstr "_Kekalkan kursor bersaiz besar ditengah-tengah"
 
 #: panels/universal-access/zoom-options.ui:370
 msgid "Magnifier cursor _pushes contents around"
-msgstr ""
+msgstr "Kursor bersaiz besar boleh me_nolak isi kandungan disekitarnya"
 
 #: panels/universal-access/zoom-options.ui:390
 msgid "Magnifier cursor moves with _contents"
-msgstr ""
+msgstr "Kursor bersaiz besar bergerak bersama-sama _isi kandungan"
 
 #: panels/universal-access/zoom-options.ui:425
 msgid "Magnifier Position:"
-msgstr ""
+msgstr "Kedudukan Pembesar:"
 
 #: panels/universal-access/zoom-options.ui:446
 msgid "Magnifier"
-msgstr "Kaca Pembesar"
+msgstr "Pembesar"
 
 #: panels/universal-access/zoom-options.ui:493
 msgid "_Thickness:"
-msgstr ""
+msgstr "Ke_tebalan:"
 
 #: panels/universal-access/zoom-options.ui:519
 msgctxt "universal access, thickness"
 msgid "Thin"
-msgstr ""
+msgstr "Nipis"
 
 #: panels/universal-access/zoom-options.ui:551
 msgctxt "universal access, thickness"
 msgid "Thick"
-msgstr ""
+msgstr "Tebal"
 
 #: panels/universal-access/zoom-options.ui:577
 msgid "_Length:"
-msgstr ""
+msgstr "_Panjang:"
 
 #. The color of the accessibility crosshair
 #: panels/universal-access/zoom-options.ui:626
 msgid "Co_lor:"
-msgstr ""
+msgstr "_Warna:"
 
 #: panels/universal-access/zoom-options.ui:690
 msgid "_Crosshairs:"
-msgstr ""
+msgstr "_Rerambut Silang:"
 
 #: panels/universal-access/zoom-options.ui:738
 msgid "_Overlaps mouse cursor"
-msgstr ""
+msgstr "_Tindih kursor tetikus"
 
 #: panels/universal-access/zoom-options.ui:776
 msgid "Crosshairs"
-msgstr ""
+msgstr "Rerambut Silang"
 
 #: panels/universal-access/zoom-options.ui:825
 msgid "_White on black:"
-msgstr ""
+msgstr "P_utih atas hitam:"
 
 #: panels/universal-access/zoom-options.ui:845
 msgid "_Brightness:"
@@ -6788,13 +6796,13 @@ msgstr "_Kecerahan:"
 
 #: panels/universal-access/zoom-options.ui:866
 msgid "_Contrast:"
-msgstr ""
+msgstr "_Beza Jelas:"
 
 #. The contrast scale goes from Color to None (grayscale)
 #: panels/universal-access/zoom-options.ui:886
 msgctxt "universal access, contrast"
 msgid "Co_lor"
-msgstr ""
+msgstr "Wa_rna"
 
 #: panels/universal-access/zoom-options.ui:911
 msgctxt "universal access, color"
@@ -6860,7 +6868,7 @@ msgstr "Kemaskini-Kemaskini Automatik"
 msgid ""
 "Allow background updates to happen automatically on this connection. These "
 "are usually upgraded apps, new content or updates to Endless OS."
-msgstr ""
+msgstr "Benarkan kemaskini-kemaskini dibalik tabir bergerak secara automatik dengan sambungan ini. Biasanya apl-apl ditatarkan, ada kandungan baharu atau kemaskini-kemaskini Endless OS."
 
 #: panels/updates/cc-updates-panel.ui:217
 msgid "Scheduled Updates"
@@ -7007,46 +7015,46 @@ msgstr "Tiada Sekatan"
 
 #: panels/user-accounts/cc-app-permissions.ui:15
 msgid "Restrict Apps"
-msgstr ""
+msgstr "Sekat Apl"
 
 #: panels/user-accounts/cc-app-permissions.ui:30
 msgid "Prevent this user from opening some apps by turning them off below."
-msgstr ""
+msgstr "Halang pengguna ini membuka beberapa apl dengan mematikannya di bawah."
 
 #: panels/user-accounts/cc-app-permissions.ui:78
 msgid "Restrict Web Browsers"
-msgstr ""
+msgstr "Sekat Pelayar Sesawang"
 
 #: panels/user-accounts/cc-app-permissions.ui:93
 msgid ""
 "Prevent this user from running web browsers by turning them off below. Note "
 "that if the computer is connected to the internet, limited web content may "
 "still be available in other applications."
-msgstr ""
+msgstr "Halang pengguna ini menjalankan pelayar sesawang dengan mematikannya di bawah. Perhatian sekiranya komputer bersambung dengan internet, kandungan sesawang terbatas masih tersedia untuk lain-lain aplikasi."
 
 #: panels/user-accounts/cc-app-permissions.ui:120
 msgid "Web _Browsers"
-msgstr ""
+msgstr "Pela_yar Sesawang"
 
 #: panels/user-accounts/cc-app-permissions.ui:153
 msgid "App Center Restrictions"
-msgstr ""
+msgstr "Sekatan Pusat Apl"
 
 #: panels/user-accounts/cc-app-permissions.ui:173
 msgid "App _Installation"
-msgstr ""
+msgstr "Pe_masangan Apl"
 
 #: panels/user-accounts/cc-app-permissions.ui:209
 msgid "Install Apps for All _Users"
-msgstr ""
+msgstr "Pasang Apl untuk Semua _Pengguna"
 
 #: panels/user-accounts/cc-app-permissions.ui:245
 msgid "Show Apps _Suitable For"
-msgstr ""
+msgstr "Tunjuk Apl Yang Sesuai Untuk"
 
 #: panels/user-accounts/cc-avatar-chooser.c:232
 msgid "Browse for more pictures"
-msgstr ""
+msgstr "Layar lagi banyak gambar"
 
 #: panels/user-accounts/cc-avatar-chooser.ui:39
 msgid "Take a Picture…"
@@ -7054,7 +7062,7 @@ msgstr "Ambil satu Gambar..."
 
 #: panels/user-accounts/cc-avatar-chooser.ui:46
 msgid "Select a File…"
-msgstr ""
+msgstr "Pilih satu Fail"
 
 #: panels/user-accounts/cc-login-history-dialog.c:69
 msgid "This Week"
@@ -7072,7 +7080,7 @@ msgstr "Minggu Lepas"
 #: panels/user-accounts/cc-login-history-dialog.c:86
 msgctxt "login history week label"
 msgid "%b %e"
-msgstr "%e %b %e"
+msgstr "%e %b"
 
 #. Translators: This is a date format string in the style of "Feb 24, 2013",
 #. shown as the last day of a week on login history dialog.
@@ -7087,7 +7095,7 @@ msgstr "%e %b, %Y"
 #, c-format
 msgctxt "login history week label"
 msgid "%s — %s"
-msgstr ""
+msgstr "%s — %s"
 
 #. Translators: This is a time format string in the style of "22:58".
 #. It indicates a login time which follows a date.
@@ -7095,7 +7103,7 @@ msgstr ""
 #: panels/user-accounts/cc-user-panel.c:773
 msgctxt "login date-time"
 msgid "%k:%M"
-msgstr ""
+msgstr "%k:%M"
 
 #. Translators: This indicates a login date-time.
 #. The first %s is a date, and the second %s a time.
@@ -7112,46 +7120,46 @@ msgstr "Sesi Tamat"
 
 #: panels/user-accounts/cc-login-history-dialog.c:249
 msgid "Session Started"
-msgstr "Sesi Bermula."
+msgstr "Sesi Bermula"
 
 #. Translators: This is the title of the "Account Activity" dialog.
 #. The %s is the user real name.
 #: panels/user-accounts/cc-login-history-dialog.c:343
 #, c-format
 msgid "%s — Account Activity"
-msgstr ""
+msgstr "Aktiviti Akaun  — %s"
 
 #: panels/user-accounts/cc-password-dialog.c:155
 msgid "Please choose another password."
-msgstr "Pilih katalaluan yang lain."
+msgstr "Sila pilih kata laluan lain."
 
 #: panels/user-accounts/cc-password-dialog.c:164
 msgid "Please type your current password again."
-msgstr "Taipkan kata laluan anda sekali lagi."
+msgstr "Sila taip kata laluan semasa anda sekali lagi."
 
 #: panels/user-accounts/cc-password-dialog.c:170
 msgid "Password could not be changed"
-msgstr "Katalaluan tidak dapat ditukar"
+msgstr "Kata laluan tidak dapat ditukarkan"
 
 #: panels/user-accounts/cc-password-dialog.ui:7
 msgid "Change Password"
-msgstr ""
+msgstr "Ubah Kata Laluan"
 
 #: panels/user-accounts/cc-password-dialog.ui:37
 msgid "Ch_ange"
-msgstr ""
+msgstr "_Ubah"
 
 #: panels/user-accounts/cc-password-dialog.ui:145
 msgid "_Confirm New Password"
-msgstr ""
+msgstr "_Sahkan Kata Laluan Baharu"
 
 #: panels/user-accounts/cc-password-dialog.ui:162
 msgid "_New Password"
-msgstr ""
+msgstr "Kata Laluan _Baharu"
 
 #: panels/user-accounts/cc-password-dialog.ui:216
 msgid "Current _Password"
-msgstr ""
+msgstr "_Kata Laluan Semasa"
 
 #: panels/user-accounts/cc-realm-manager.c:307
 msgid "Cannot automatically join this type of domain"
@@ -7169,7 +7177,7 @@ msgstr "Tidak dapat mendaftar masuk sebagai %s pada domain %s"
 
 #: panels/user-accounts/cc-realm-manager.c:738
 msgid "Invalid password, please try again"
-msgstr "Katalaluan tidak sah. Cuba semula."
+msgstr "Kata laluan tidak sah. Cuba sekali lagi."
 
 #: panels/user-accounts/cc-realm-manager.c:751
 #, c-format
@@ -7178,7 +7186,7 @@ msgstr "Tidak dapat menyambung ke domain %s: %s"
 
 #: panels/user-accounts/cc-user-panel.c:216
 msgid "Your account"
-msgstr ""
+msgstr "Akaun anda"
 
 #: panels/user-accounts/cc-user-panel.c:391
 msgid "Failed to delete user"
@@ -7188,33 +7196,33 @@ msgstr "Gagal memadam pengguna"
 #: panels/user-accounts/cc-user-panel.c:508
 #: panels/user-accounts/cc-user-panel.c:560
 msgid "Failed to revoke remotely managed user"
-msgstr ""
+msgstr "Gagal menyeru pengguna terurus secara jauh"
 
 #: panels/user-accounts/cc-user-panel.c:612
 msgid "You cannot delete your own account."
-msgstr ""
+msgstr "Anda tidak boleh memadam akaun anda sendiri."
 
 #: panels/user-accounts/cc-user-panel.c:621
 #, c-format
 msgid "%s is still logged in"
-msgstr "%s belum log keluar"
+msgstr "%s masih mendaftar masuk"
 
 #: panels/user-accounts/cc-user-panel.c:625
 msgid ""
 "Deleting a user while they are logged in can leave the system in an "
 "inconsistent state."
-msgstr ""
+msgstr "Memadam seorang pengguna ketika mereka masih mendaftar masuk boleh menyebabkan sistem dalam keadaan tidak konsisten."
 
 #: panels/user-accounts/cc-user-panel.c:634
 #, c-format
 msgid "Do you want to keep %s’s files?"
-msgstr ""
+msgstr "Anda mahu mengekalkan fail-fail %s?"
 
 #: panels/user-accounts/cc-user-panel.c:638
 msgid ""
 "It is possible to keep the home directory, mail spool and temporary files "
 "around when deleting a user account."
-msgstr ""
+msgstr "Boleh mengekalkan direktori rumah, kili mel dan fail-fail sementara ketika memadam satu akaun pengguna."
 
 #: panels/user-accounts/cc-user-panel.c:641
 msgid "_Delete Files"
@@ -7227,7 +7235,7 @@ msgstr "_Kekalkan Fail"
 #: panels/user-accounts/cc-user-panel.c:656
 #, c-format
 msgid "Are you sure you want to revoke remotely managed %s’s account?"
-msgstr ""
+msgstr "Anda pasti mahu menyerus akaun %s yang diurus secara jauh?"
 
 #: panels/user-accounts/cc-user-panel.c:660
 msgid "_Delete"
@@ -7241,7 +7249,7 @@ msgstr "Akaun dilumpuhkan"
 #: panels/user-accounts/cc-user-panel.c:718
 msgctxt "Password mode"
 msgid "To be set at next login"
-msgstr ""
+msgstr "Untuk ditetapkan pada daftar masuk berikutnya"
 
 #: panels/user-accounts/cc-user-panel.c:721
 msgctxt "Password mode"
@@ -7250,15 +7258,15 @@ msgstr "Tiada"
 
 #: panels/user-accounts/cc-user-panel.c:766
 msgid "Logged in"
-msgstr "Telah log masuk"
+msgstr "Telah mendaftar masuk"
 
 #: panels/user-accounts/cc-user-panel.c:1103
 msgid "Failed to contact the accounts service"
-msgstr ""
+msgstr "Gagal menghubungi perkhidmatan akaun"
 
 #: panels/user-accounts/cc-user-panel.c:1105
 msgid "Please make sure that the AccountService is installed and enabled."
-msgstr ""
+msgstr "Sila pastikan AccountService telah dipasang dan dibenarkan."
 
 #. Translator comments:
 #. * We split the line in 2 here to "make it look good", as there's
@@ -7268,7 +7276,7 @@ msgstr ""
 msgid ""
 "To make changes,\n"
 "click the * icon first"
-msgstr ""
+msgstr "Untuk membuat perubahan,\nklik ikon * terlebih dahulu"
 
 #: panels/user-accounts/cc-user-panel.c:1212
 msgid "Create a user account"
@@ -7279,61 +7287,61 @@ msgstr "Cipta satu akaun pengguna"
 msgid ""
 "To create a user account,\n"
 "click the * icon first"
-msgstr ""
+msgstr "Untuk mencipta satu akaun pengguna,\nklik ikon * terlebih dahulu"
 
 #: panels/user-accounts/cc-user-panel.c:1232
 msgid "Delete the selected user account"
-msgstr "Padam akaun pengguna dipilih"
+msgstr "Padam akaun pengguna terpilih"
 
 #: panels/user-accounts/cc-user-panel.c:1244
 #: panels/user-accounts/cc-user-panel.c:1356
 msgid ""
 "To delete the selected user account,\n"
 "click the * icon first"
-msgstr ""
+msgstr "Untuk memadam akaun pengguna terpilih,\nklik ikon * terlebih dahulu"
 
 #: panels/user-accounts/cc-user-panel.ui:18
 msgid "_Add User…"
-msgstr ""
+msgstr "_Tambah Pengguna..."
 
 #: panels/user-accounts/cc-user-panel.ui:70
 msgid "Your session needs to be restarted for changes to take effect"
-msgstr ""
+msgstr "Sesi anda perlu dimulakan semula supaya perubahan yang dibuat berkesan"
 
 #: panels/user-accounts/cc-user-panel.ui:78
 msgid "Restart Now"
-msgstr "Mulakan Semula Sekarang"
+msgstr "Mula Semula Sekarang"
 
 #: panels/user-accounts/cc-user-panel.ui:261
 msgid "A_utomatic Login"
-msgstr ""
+msgstr "Daftar Masuk A_utomatik"
 
 #: panels/user-accounts/cc-user-panel.ui:303
 msgid "_Fingerprint Login"
-msgstr ""
+msgstr "Daftar Masuk Ber_cap Jari"
 
 #: panels/user-accounts/cc-user-panel.ui:329
 #: panels/user-accounts/cc-user-panel.ui:345
 msgid "User Icon"
-msgstr ""
+msgstr "Ikon Pengguna"
 
 #: panels/user-accounts/cc-user-panel.ui:409
 msgid "Last Login"
-msgstr ""
+msgstr "Daftar Masuk Terakhir"
 
 #: panels/user-accounts/cc-user-panel.ui:474
 msgid "Remove User…"
-msgstr ""
+msgstr "Buang Pengguna..."
 
 #. Translators: This is the empty state page label which states that there are
 #. no users to show in the panel.
 #: panels/user-accounts/cc-user-panel.ui:507
 msgid "No Users Found"
-msgstr ""
+msgstr "Tiada Pengguna Ditemui"
 
 #: panels/user-accounts/cc-user-panel.ui:517
 msgid "Unlock to add a user account."
-msgstr ""
+msgstr "Nyahkunci untuk menambah satu akaun pengguna."
 
 #: panels/user-accounts/data/account-fingerprint.ui:12
 msgid "Left thumb"
@@ -7349,7 +7357,7 @@ msgstr "Jari manis kiri"
 
 #: panels/user-accounts/data/account-fingerprint.ui:21
 msgid "Left little finger"
-msgstr "Jari anak kiri"
+msgstr "Jari kelingking kiri"
 
 #: panels/user-accounts/data/account-fingerprint.ui:24
 msgid "Right thumb"
@@ -7365,12 +7373,12 @@ msgstr "Jari manis kanan"
 
 #: panels/user-accounts/data/account-fingerprint.ui:33
 msgid "Right little finger"
-msgstr "Jari anak"
+msgstr "Jari kelingking kanan"
 
 #: panels/user-accounts/data/account-fingerprint.ui:39
 #: panels/user-accounts/um-fingerprint-dialog.c:677
 msgid "Enable Fingerprint Login"
-msgstr "Bolehkan Log Masuk Cap Jari"
+msgstr "Benarkan Daftar Masuk Bercap Jari"
 
 #: panels/user-accounts/data/account-fingerprint.ui:89
 msgid "_Right index finger"
@@ -7382,555 +7390,555 @@ msgstr "Jari tengah k_iri"
 
 #: panels/user-accounts/data/account-fingerprint.ui:126
 msgid "_Other finger:"
-msgstr "Jari _lain:"
+msgstr "_Lain-lain jari:"
 
 #: panels/user-accounts/data/account-fingerprint.ui:324
 msgid ""
 "Your fingerprint was successfully saved. You should now be able to log in "
 "using your fingerprint reader."
-msgstr ""
+msgstr "Cap jari anda berjaya disimpan. Anda kini boleh mendaftar masuk menggunakan pembaca cap jari anda."
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:3
 msgid "Users"
-msgstr ""
+msgstr "Pengguna"
 
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:4
 msgid "Add or remove users and change your password"
-msgstr ""
+msgstr "Tambah atau buang para pengguna dan ubah kata laluan anda"
 
 #. Translators: Do NOT translate or transliterate this text (this is an icon
 #. file name)!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:7
 msgid "system-users"
-msgstr ""
+msgstr "system-users"
 
 #. Translators: Search terms to find the Users panel. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
 #: panels/user-accounts/data/gnome-user-accounts-panel.desktop.in.in:19
 msgid ""
 "Login;Name;Fingerprint;Avatar;Logo;Face;Password;Parental;Restrict;Restrictions;"
-msgstr ""
+msgstr "DaftarMasuk;Nama;CapJari;Avatar;Logo;Wajah;KataLaluan;IbuBapa;Sekat;Sekatan;"
 
 #. Translators: This button enrolls the computer in the domain in order to use
 #. enterprise logins.
 #: panels/user-accounts/data/join-dialog.ui:39
 msgid "_Enroll"
-msgstr ""
+msgstr "_Daftar"
 
 #: panels/user-accounts/data/join-dialog.ui:75
 msgid "Domain Administrator Login"
-msgstr "Login Pengurus Domain"
+msgstr "Daftar Masuk Pentadbir Domain"
 
 #: panels/user-accounts/data/join-dialog.ui:93
 msgid ""
 "In order to use enterprise logins, this computer needs to be\n"
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here."
-msgstr ""
+msgstr "Untuk menggunakan daftar masuk enterprise, komputer ini perlu\nberdaftar ke dalam domain. Pastikan pentadbir rangkaian anda \nmenaip kata laluan domain di sini."
 
 #: panels/user-accounts/data/join-dialog.ui:150
 msgid "Administrator _Name"
-msgstr "Nama Pengu_rus"
+msgstr "Nama Penta_dbir"
 
 #: panels/user-accounts/data/join-dialog.ui:185
 msgid "Administrator Password"
-msgstr "Katalaluan Pengurus"
+msgstr "Kata Laluan Pentadbir"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:76
 msgid "No cartoon violence"
-msgstr ""
+msgstr "Tiada aksi keganasan kartun"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:79
 msgid "Cartoon characters in unsafe situations"
-msgstr ""
+msgstr "Karakter-karakter kartun dalam situasi-situasi tidak selamat"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:82
 msgid "Cartoon characters in aggressive conflict"
-msgstr ""
+msgstr "Karakter-karakter kartun berada dalam konflik yang agresif"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:85
 msgid "Graphic violence involving cartoon characters"
-msgstr ""
+msgstr "Keganasan dalam bentuk grafik yang melibatkan karakter-karakter kartun"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:88
 msgid "No fantasy violence"
-msgstr ""
+msgstr "Tiada aksi keganasan fantasi"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:91
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr ""
+msgstr "Karakter-karakter dalam situasi tidak selamat yang mudah dibezakan dengan realiti"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:94
 msgid "Characters in aggressive conflict easily distinguishable from reality"
-msgstr ""
+msgstr "Karakter-karakter berada dalam konflik agresif yang mudah dibezakan dengan realiti"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:97
 msgid "Graphic violence easily distinguishable from reality"
-msgstr ""
+msgstr "Keganasan dalam bentuk grafik yang mudah dibezakan dengan realiti"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:100
 msgid "No realistic violence"
-msgstr ""
+msgstr "Tiada aksi keganasan realistik"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:103
 msgid "Mildly realistic characters in unsafe situations"
-msgstr ""
+msgstr "Karakter-karakter berkeadaan sedikit realistik dalam situasi-situasi tidak selamat"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:106
 msgid "Depictions of realistic characters in aggressive conflict"
-msgstr ""
+msgstr "Pelukisan karakter-karakter berkeadaan realistik dengan konflik agresif"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:109
 msgid "Graphic violence involving realistic characters"
-msgstr ""
+msgstr "Keganasan dalam bentuk grafik yang melibatkan karakter-karakter berkeadaan realistik"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:112
 msgid "No bloodshed"
-msgstr ""
+msgstr "Tiada pertumpahan darah"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:115
 msgid "Unrealistic bloodshed"
-msgstr ""
+msgstr "Pertumpahan darah tidak realistik"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:118
 msgid "Realistic bloodshed"
-msgstr ""
+msgstr "Pertumpahan darah yang realistik"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:121
 msgid "Depictions of bloodshed and the mutilation of body parts"
-msgstr ""
+msgstr "Pelukisan pertumpahan darah dan pencacatan anggota badan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:124
 msgid "No sexual violence"
-msgstr ""
+msgstr "Tiada aksi keganasan seks"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:127
 msgid "Rape or other violent sexual behavior"
-msgstr ""
+msgstr "Aksi rogol atau lain-lain kelakuan seks ganas"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:130
 msgid "No references to alcohol"
-msgstr ""
+msgstr "Tiada penggambaran berkenaan alkohol"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:133
 msgid "References to alcoholic beverages"
-msgstr ""
+msgstr "Gambaran berkenaan minuman beralkohol"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:136
 msgid "Use of alcoholic beverages"
-msgstr ""
+msgstr "Penggunaan minuman beralkohol"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:139
 msgid "No references to illicit drugs"
-msgstr ""
+msgstr "Tiada penggambaran berkenaan dadah-dadah terlarang"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:142
 msgid "References to illicit drugs"
-msgstr ""
+msgstr "Gambaran berkenaan dadah-dadah terlarang"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:145
 msgid "Use of illicit drugs"
-msgstr ""
+msgstr "Penggunaan dadah-dadah terlarang"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:148
 msgid "References to tobacco products"
-msgstr ""
+msgstr "Gambaran berkenaan produk-produk tembakau"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:151
 msgid "Use of tobacco products"
-msgstr ""
+msgstr "Penggunaan produk-produk tembakau"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:154
 msgid "No nudity of any sort"
-msgstr ""
+msgstr "Tiada unsur-unsur kebogelan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:157
 msgid "Brief artistic nudity"
-msgstr ""
+msgstr "Sedikit unsur-unsur kebogelan bersifat artistik"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:160
 msgid "Prolonged nudity"
-msgstr ""
+msgstr "Gambaran kebogelan yang berlanjutan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:163
 msgid "No references or depictions of sexual nature"
-msgstr ""
+msgstr "Tiada gambaran berkenaan tabiat-tabiat seks"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:166
 msgid "Provocative references or depictions"
-msgstr ""
+msgstr "Gambaran berkenaan sikap-sikap provokatif"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:169
 msgid "Sexual references or depictions"
-msgstr ""
+msgstr "Gambaran berkenaan aksi-aksi seksual"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:172
 msgid "Graphic sexual behavior"
-msgstr ""
+msgstr "Kelakuan seksual yang jelas dan nyata"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:175
 msgid "No profanity of any kind"
-msgstr ""
+msgstr "Tiada aksi-aksi tidak senonoh"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:178
 msgid "Mild or infrequent use of profanity"
-msgstr ""
+msgstr "Sedikit atau jarang-jarang kelakuan tidak senonoh"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:181
 msgid "Moderate use of profanity"
-msgstr ""
+msgstr "Ada pelakuan tidak senonoh"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:184
 msgid "Strong or frequent use of profanity"
-msgstr ""
+msgstr "Aksi-aksi tidak senonoh kerap ditayangkan atau sangat menonjol"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:187
 msgid "No inappropriate humor"
-msgstr ""
+msgstr "Tiada lawak tidak senonoh"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:190
 msgid "Slapstick humor"
-msgstr ""
+msgstr "Lawak bodoh"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:193
 msgid "Vulgar or bathroom humor"
-msgstr ""
+msgstr "Lawak ganas"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:196
 msgid "Mature or sexual humor"
-msgstr ""
+msgstr "Lawak dewasa atau seks"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:199
 msgid "No discriminatory language of any kind"
-msgstr ""
+msgstr "Tiada pengucapan bersifat diskriminasi"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:202
 msgid "Negativity towards a specific group of people"
-msgstr ""
+msgstr "Ada unsur-unsur negatif yang khusus kepada kumpulan tertentu"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:205
 msgid "Discrimination designed to cause emotional harm"
-msgstr ""
+msgstr "Ada unsur-unsur diskriminasi yang mengugat emos"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:208
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
-msgstr ""
+msgstr "Ada unsur-unsur diskriminasi terhadap jantina, seks, bangsa atau agama"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:211
 msgid "No advertising of any kind"
-msgstr ""
+msgstr "Tiada pengiklanan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:214
 msgid "Product placement"
-msgstr ""
+msgstr "Ada memaparkan produk-produk tertentu"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:217
 msgid "Explicit references to specific brands or trademarked products"
-msgstr ""
+msgstr "Gambaran jelas terhadap jenama-jenama atau produk-produk tertentu"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:220
 msgid "Users are encouraged to purchase specific real-world items"
-msgstr ""
+msgstr "Para pengguna digalakkan membeli item-item sebenar"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:223
 msgid "No gambling of any kind"
-msgstr ""
+msgstr "Tiada aksi-aksi perjudian"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:226
 msgid "Gambling on random events using tokens or credits"
-msgstr ""
+msgstr "Ada unsur-unsur perjudian pada acara-acara secara rawak menggunakan token atau kredit"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:229
 msgid "Gambling using “play” money"
-msgstr ""
+msgstr "Ada aksi perjudian menggunakan duit \"khusus\""
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:232
 msgid "Gambling using real money"
-msgstr ""
+msgstr "Ada aksi perjudian menggunakan duit sebenar"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:235
 msgid "No ability to spend money"
-msgstr ""
+msgstr "Tidak melibatkan penggunaan duit"
 
 #. v1.1
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:238
 msgid "Users are encouraged to donate real money"
-msgstr ""
+msgstr "Para pengguna digalakkan menderma duit sebenar"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:241
 msgid "Ability to spend real money in-game"
-msgstr ""
+msgstr "Ada fungsi yang melibatkan duit di dalam permainan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:244
 msgid "No way to chat with other users"
-msgstr ""
+msgstr "Tiada fungsi sembang dengan pengguna lain"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:247
 msgid "User-to-user game interactions without chat functionality"
-msgstr ""
+msgstr "Interaksi permainan pengguna-dengan-pengguna tanpa fungsi sembang"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:250
 msgid "Moderated chat functionality between users"
-msgstr ""
+msgstr "Ada fungsi sembang bersifat sederhana antara pengguna "
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:253
 msgid "Uncontrolled chat functionality between users"
-msgstr ""
+msgstr "Ada fungsi sembang tanpa kawalan antara pengguna"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:256
 msgid "No way to talk with other users"
-msgstr ""
+msgstr "Tiada fungsi berbual dengan pengguna lain"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:259
 msgid "Uncontrolled audio or video chat functionality between users"
-msgstr ""
+msgstr "Ada fungsi sembang audio atau video tanpa kawalan antara pengguna"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:262
 msgid "No sharing of social network usernames or email addresses"
-msgstr ""
+msgstr "Tiada perkongsian nama pengguna rangkaian sosial atau alamat emel"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:265
 msgid "Sharing social network usernames or email addresses"
-msgstr ""
+msgstr "Ada perkongsian nama pengguna rangkaian sosial atau alamat emel"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:268
 msgid "No sharing of user information with 3rd parties"
-msgstr ""
+msgstr "Tiada perkongsian maklumat pengguna dengan pihak ke-3"
 
 #. v1.1
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:271
 msgid "Checking for the latest application version"
-msgstr ""
+msgstr "Ada pemeriksaan versi aplikasi yang terkini"
 
 #. v1.1
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:274
 msgid "Sharing diagnostic data that does not let others identify the user"
-msgstr ""
+msgstr "Ada perkongsian data diagnostik yang membolehkan orang lain dapat mengenal pasti pengguna"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:277
 msgid "Sharing information that lets others identify the user"
-msgstr ""
+msgstr "Ada perkongsian maklumat yang membolehkan orang lain dapat mengenal pasti pengguna"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:280
 msgid "No sharing of physical location to other users"
-msgstr ""
+msgstr "Tiada perkongsian lokasi sebenar dengan pengguna lain"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:283
 msgid "Sharing physical location to other users"
-msgstr ""
+msgstr "Ada perkongsian lokasi sebenar dengan pengguna lain"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:288
 msgid "No references to homosexuality"
-msgstr ""
+msgstr "Tiada gambaran berkenaan homoseks"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:291
 msgid "Indirect references to homosexuality"
-msgstr ""
+msgstr "Gambaran tidak langsung berkenaan homoseks"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:294
 msgid "Kissing between people of the same gender"
-msgstr ""
+msgstr "Ada adegan cium antara sama jantina"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:297
 msgid "Graphic sexual behavior between people of the same gender"
-msgstr ""
+msgstr "Ada adegan seks bergrafik antara sama jantina"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:300
 msgid "No references to prostitution"
-msgstr ""
+msgstr "Tiada gambaran berkenaan pelacuran"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:303
 msgid "Indirect references to prostitution"
-msgstr ""
+msgstr "Gambaran tidak langsung berkenaan pelacuran"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:306
 msgid "Direct references to prostitution"
-msgstr ""
+msgstr "Ada gambaran jelas berkenaan pelacuran"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:309
 msgid "Graphic depictions of the act of prostitution"
-msgstr ""
+msgstr "Ada gambaran bergrafik aksi-aksi pelacuran"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:312
 msgid "No references to adultery"
-msgstr ""
+msgstr "Tiada penggambaran berkenaan zina"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:315
 msgid "Indirect references to adultery"
-msgstr ""
+msgstr "Ada gambaran tidak langsung berkenaan zina"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:318
 msgid "Direct references to adultery"
-msgstr ""
+msgstr "Ada gambaran jelas berkenaan zina"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:321
 msgid "Graphic depictions of the act of adultery"
-msgstr ""
+msgstr "Ada gambaran bergrafik aksi-aksi penzinaan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:324
 msgid "No sexualized characters"
-msgstr ""
+msgstr "Tiada karakter-karakter seks"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:327
 msgid "Scantily clad human characters"
-msgstr ""
+msgstr "Ada karakter-karakter manusia hampir tidak berpakaian"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:330
 msgid "Overtly sexualized human characters"
-msgstr ""
+msgstr "Ada karakter-karakter manusia berkelakuan seks yang melampau"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:333
 msgid "No references to desecration"
-msgstr ""
+msgstr "Tiada gambaran berkenaan penodaan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:336
 msgid "Depictions or references to historical desecration"
-msgstr ""
+msgstr "Ada gambaran berkenaan penodaan bersejarah"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:339
 msgid "Depictions of modern-day human desecration"
-msgstr ""
+msgstr "Ada gambaran berkenaan penodaan manusia di era modern"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:342
 msgid "Graphic depictions of modern-day desecration"
-msgstr ""
+msgstr "Ada gambaran jelas penodaan di era modern"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:345
 msgid "No visible dead human remains"
-msgstr ""
+msgstr "Tiada penampakan mayat"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:348
 msgid "Visible dead human remains"
-msgstr ""
+msgstr "Ada penampakan mayat"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:351
 msgid "Dead human remains that are exposed to the elements"
-msgstr ""
+msgstr "Ada penampakan mayat yang telah terdedah dengan persekitaran"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:354
 msgid "Graphic depictions of desecration of human bodies"
-msgstr ""
+msgstr "Ada gambaran jelas penodaan jasad manusia"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:357
 msgid "No references to slavery"
-msgstr ""
+msgstr "Tiada gambaran berkenaan perhambaan"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:360
 msgid "Depictions or references to historical slavery"
-msgstr ""
+msgstr "Ada gambaran berkenaan perhambaan bersejarah"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:363
 msgid "Depictions of modern-day slavery"
-msgstr ""
+msgstr "Ada gambaran berkenaan perhambaan di era modern"
 
 #. TRANSLATORS: content rating description
 #: panels/user-accounts/gs-content-rating.c:366
 msgid "Graphic depictions of modern-day slavery"
-msgstr ""
+msgstr "Ada gambaran jelas perhambaan di era modern"
 
 #: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:11
 msgid "Manage user accounts"
-msgstr ""
+msgstr "Urus akaun-akaun pengguna"
 
 #: panels/user-accounts/org.gnome.controlcenter.user-accounts.policy.in:12
 msgid "Authentication is required to change user data"
-msgstr ""
+msgstr "Pengesahihan diperlukan untuk mengubah data pengguna"
 
 #: panels/user-accounts/pw-utils.c:94
 msgctxt "Password hint"
@@ -7940,86 +7948,86 @@ msgstr "Kata laluan baharu mesti berbeza dengan yang lama."
 #: panels/user-accounts/pw-utils.c:96
 msgctxt "Password hint"
 msgid "Try changing some letters and numbers."
-msgstr ""
+msgstr "Cuba ubah beberapa abjad dan angka"
 
 #: panels/user-accounts/pw-utils.c:98 panels/user-accounts/pw-utils.c:106
 msgctxt "Password hint"
 msgid "Try changing the password a bit more."
-msgstr ""
+msgstr "Cuba ubah lagi kata laluan ini."
 
 #: panels/user-accounts/pw-utils.c:100
 msgctxt "Password hint"
 msgid "A password without your user name would be stronger."
-msgstr ""
+msgstr "Kata laluan tanpa melibatkan nama pengguna anda adalah lebih mantap."
 
 #: panels/user-accounts/pw-utils.c:102
 msgctxt "Password hint"
 msgid "Try to avoid using your name in the password."
-msgstr ""
+msgstr "Cuba hindari nama anda di dalam kata laluan."
 
 #: panels/user-accounts/pw-utils.c:104
 msgctxt "Password hint"
 msgid "Try to avoid some of the words included in the password."
-msgstr ""
+msgstr "Cuba hindari beberapa perkataan yang ada di dalam kata laluan."
 
 #: panels/user-accounts/pw-utils.c:108
 msgctxt "Password hint"
 msgid "Try to avoid common words."
-msgstr ""
+msgstr "Cuba hindari perkataan umum yang biasa digunakan."
 
 #: panels/user-accounts/pw-utils.c:110
 msgctxt "Password hint"
 msgid "Try to avoid reordering existing words."
-msgstr ""
+msgstr "Cuba hindari menyusun semula perkataan yang sedia ada."
 
 #: panels/user-accounts/pw-utils.c:112
 msgctxt "Password hint"
 msgid "Try to use more numbers."
-msgstr ""
+msgstr "Cuba masukkan lebih banyak nombor."
 
 #: panels/user-accounts/pw-utils.c:114
 msgctxt "Password hint"
 msgid "Try to use more uppercase letters."
-msgstr ""
+msgstr "Cuba gandingkan dengan beberapa abjad berhuruf besar."
 
 #: panels/user-accounts/pw-utils.c:116
 msgctxt "Password hint"
 msgid "Try to use more lowercase letters."
-msgstr ""
+msgstr "Cuba gandingkan dengan beberapa abjad berhuruf kecil."
 
 #: panels/user-accounts/pw-utils.c:118
 msgctxt "Password hint"
 msgid "Try to use more special characters, like punctuation."
-msgstr ""
+msgstr "Cuba gandingkan dengan aksara-aksara khas, seperti tanda baca."
 
 #: panels/user-accounts/pw-utils.c:120
 msgctxt "Password hint"
 msgid "Try to use a mixture of letters, numbers and punctuation."
-msgstr ""
+msgstr "Cuba gabungkan dengan beberapa abjad, nombor dan tanda baca."
 
 #: panels/user-accounts/pw-utils.c:122
 msgctxt "Password hint"
 msgid "Try to avoid repeating the same character."
-msgstr ""
+msgstr "Cuba hindari mengulangi beberapa aksara yang serupa."
 
 #: panels/user-accounts/pw-utils.c:124
 msgctxt "Password hint"
 msgid ""
 "Try to avoid repeating the same type of character: you need to mix up "
 "letters, numbers and punctuation."
-msgstr ""
+msgstr "Cuba hindari pengulangan jenis aksara yang sama: anda perlu gabungkan beberapa abjad, nombor dan tanda baca."
 
 #: panels/user-accounts/pw-utils.c:126
 msgctxt "Password hint"
 msgid "Try to avoid sequences like 1234 or abcd."
-msgstr ""
+msgstr "Cuba hindari turutan seperti 1234 atau abcd."
 
 #: panels/user-accounts/pw-utils.c:128
 msgctxt "Password hint"
 msgid ""
 "Password needs to be longer. Try to add more letters, numbers and "
 "punctuation."
-msgstr ""
+msgstr "Kata laluan perlu lebih panjang aksaranya. Tambah lagi beberapa abjad, nombor dan tanda baca."
 
 #: panels/user-accounts/pw-utils.c:130
 msgctxt "Password hint"
@@ -8035,47 +8043,47 @@ msgstr "Dengan menambah beberapa abjad, nombor dan tanda baca, kata laluan anda 
 
 #: panels/user-accounts/run-passwd.c:422
 msgid "Authentication failed"
-msgstr ""
+msgstr "Pengesahihan gagal"
 
 #: panels/user-accounts/run-passwd.c:502
 #, c-format
 msgid "The new password is too short"
-msgstr ""
+msgstr "Kata laluan baharu terlalu pendek"
 
 #: panels/user-accounts/run-passwd.c:508
 #, c-format
 msgid "The new password is too simple"
-msgstr ""
+msgstr "Kata laluan baharu terlalu mudah"
 
 #: panels/user-accounts/run-passwd.c:514
 #, c-format
 msgid "The old and new passwords are too similar"
-msgstr ""
+msgstr "Kata laluan lama dan baru hampir sama"
 
 #: panels/user-accounts/run-passwd.c:517
 #, c-format
 msgid "The new password has already been used recently."
-msgstr ""
+msgstr "Kata laluan baharu telah digunakan baru-baru ini"
 
 #: panels/user-accounts/run-passwd.c:520
 #, c-format
 msgid "The new password must contain numeric or special characters"
-msgstr ""
+msgstr "Kata laluan baharu mesti mengandungi beberapa angka atau aksara khas"
 
 #: panels/user-accounts/run-passwd.c:524
 #, c-format
 msgid "The old and new passwords are the same"
-msgstr ""
+msgstr "Kata laluan lama dan baru adalah serupa"
 
 #: panels/user-accounts/run-passwd.c:528
 #, c-format
 msgid "Your password has been changed since you initially authenticated!"
-msgstr ""
+msgstr "Kata laluan anda telah diubah semenjak ana mula-mula sahihkan!"
 
 #: panels/user-accounts/run-passwd.c:532
 #, c-format
 msgid "The new password does not contain enough different characters"
-msgstr ""
+msgstr "Kata laluan baharu tidak mengandungi aksara-aksara yang berbeza"
 
 #: panels/user-accounts/run-passwd.c:536
 #, c-format
@@ -8086,7 +8094,7 @@ msgstr "Ralat tidak diketahui"
 msgid ""
 "The username should usually only consist of lower case letters from a-z, "
 "digits and the following characters: - _"
-msgstr ""
+msgstr "Nama pengguna seharusnya mengandungi huruf besar atau huruf kecil a-z, digit dan aksara-aksara berikut: . - _"
 
 #: panels/user-accounts/user-utils.c:431
 msgid "Sorry, that user name isn’t available. Please try another."
@@ -8103,7 +8111,7 @@ msgstr "Tindakan ini akan menggunakan nama folder rumah anda dan ia tidak boleh 
 #: panels/user-accounts/um-fingerprint-dialog.c:139
 msgid ""
 "You are not allowed to access the device. Contact your system administrator."
-msgstr "Tidak tidak dibenarkan akses pada peranti. Hubungi sistem pentadbir anda."
+msgstr "Anda tidak dibenarkan mencapai peranti. Hubungi pentadbir sistem anda."
 
 #: panels/user-accounts/um-fingerprint-dialog.c:141
 msgid "The device is already in use."
@@ -8111,15 +8119,15 @@ msgstr "Peranti tersebut sedang digunakan"
 
 #: panels/user-accounts/um-fingerprint-dialog.c:143
 msgid "An internal error occurred."
-msgstr "Satu ralat dalaman telah terjadi."
+msgstr "Satu ralat dalaman telah berlaku."
 
 #: panels/user-accounts/um-fingerprint-dialog.c:214
 msgid "Enabled"
-msgstr "Bolehkan"
+msgstr "Dibenarkan"
 
 #: panels/user-accounts/um-fingerprint-dialog.c:260
 msgid "Delete registered fingerprints?"
-msgstr "Padam cap jari didaftarkan?"
+msgstr "Padam cap jari berdaftar?"
 
 #: panels/user-accounts/um-fingerprint-dialog.c:264
 msgid "_Delete Fingerprints"
@@ -8129,7 +8137,7 @@ msgstr "_Padam Cap Jari"
 msgid ""
 "Do you want to delete your registered fingerprints so fingerprint login is "
 "disabled?"
-msgstr ""
+msgstr "Anda pasti mahu memadam cap jari berdaftar anda supaya daftar masuk bercap jari dilumpuhkan?"
 
 #: panels/user-accounts/um-fingerprint-dialog.c:440
 msgid "Done!"
@@ -8142,7 +8150,7 @@ msgstr "Selesai!"
 #: panels/user-accounts/um-fingerprint-dialog.c:543
 #, c-format
 msgid "Could not access “%s” device"
-msgstr ""
+msgstr "Tidak dapat mencapai peranti \"%s\""
 
 #. translators:
 #. * The variable is the name of the device, for example:
@@ -8150,15 +8158,15 @@ msgstr ""
 #: panels/user-accounts/um-fingerprint-dialog.c:584
 #, c-format
 msgid "Could not start finger capture on “%s” device"
-msgstr ""
+msgstr "Tidak dapat memulakan tangkapan cari pada peranti \"%s\""
 
 #: panels/user-accounts/um-fingerprint-dialog.c:628
 msgid "Could not access any fingerprint readers"
-msgstr ""
+msgstr "Tidak dapat mencapai mana-mana pembaca cap jari"
 
 #: panels/user-accounts/um-fingerprint-dialog.c:629
 msgid "Please contact your system administrator for help."
-msgstr ""
+msgstr "Sila hubungi pentadbir sistem anda untuk mendapatkan bantuan."
 
 #. translators:
 #. * The variable is the name of the device, for example:
@@ -8170,7 +8178,7 @@ msgstr ""
 msgid ""
 "To enable fingerprint login, you need to save one of your fingerprints, "
 "using the “%s” device."
-msgstr ""
+msgstr "Untuk membenarkan daftar masuk bercap jari, anda perlu menyimpan salah satu cap jari anda, menggunakan peranti \"%s\"."
 
 #: panels/user-accounts/um-fingerprint-dialog.c:718
 msgid "Selecting finger"
@@ -8186,38 +8194,38 @@ msgstr "Petakan Butang"
 
 #: panels/wacom/button-mapping.ui:71
 msgid "Map buttons to functions"
-msgstr ""
+msgstr "Petakan butang untuk diberi fungsi"
 
 #: panels/wacom/button-mapping.ui:119
 msgid ""
 "To edit a shortcut, choose the “Send Keystroke” action, press the keyboard "
 "shortcut button and hold down the new keys or press Backspace to clear."
-msgstr ""
+msgstr "Untuk menyunting pintasan, pilih tindakan \"Hantar Ketukan Kekunci\", tekan butang pintasan papan kekunci dan tahan kekunci baharu atau tekan kekunci Backspace untuk kosongkan."
 
 #: panels/wacom/calibrator/calibrator.ui:61
 msgid ""
 "Please tap the target markers as they appear on screen to calibrate the "
 "tablet."
-msgstr ""
+msgstr "Sila ketika penanda sasaran apabila ia muncul di atas skrin untuk menentukur tablet."
 
 #: panels/wacom/calibrator/calibrator.ui:78
 msgid "Mis-click detected, restarting…"
-msgstr ""
+msgstr "Tersilap-klik dikesan, memulakan semula..."
 
 #: panels/wacom/cc-wacom-button-row.c:253
 #, c-format
 msgid "Button %d"
-msgstr ""
+msgstr "Butang %d"
 
 #: panels/wacom/cc-wacom-button-row.h:34
 msgctxt "Wacom action-type"
 msgid "Application defined"
-msgstr ""
+msgstr "Aplikasi ditakrifkan"
 
 #: panels/wacom/cc-wacom-button-row.h:35
 msgctxt "Wacom action-type"
 msgid "Send Keystroke"
-msgstr ""
+msgstr "Hantar Ketukan Kekunci"
 
 #: panels/wacom/cc-wacom-button-row.h:36
 msgctxt "Wacom action-type"
@@ -8227,7 +8235,7 @@ msgstr "Tukar Monitor"
 #: panels/wacom/cc-wacom-button-row.h:37
 msgctxt "Wacom action-type"
 msgid "Show On-Screen Help"
-msgstr ""
+msgstr "Tunjuk Bantuan Atas-Skrin"
 
 #: panels/wacom/cc-wacom-mapping-panel.c:256
 msgid "Output:"
@@ -8236,7 +8244,7 @@ msgstr "Output:"
 #. Keep ratio switch
 #: panels/wacom/cc-wacom-mapping-panel.c:268
 msgid "Keep aspect ratio (letterbox):"
-msgstr ""
+msgstr "Kekalkan nisbah bidang (peti surat):"
 
 #. Whole-desktop checkbox
 #: panels/wacom/cc-wacom-mapping-panel.c:279
@@ -8246,7 +8254,7 @@ msgstr "Petakan ke monitor tunggal"
 #: panels/wacom/cc-wacom-nav-button.c:84
 #, c-format
 msgid "%d of %d"
-msgstr ""
+msgstr "%d daripada %d"
 
 #: panels/wacom/cc-wacom-page.c:530
 msgid "Display Mapping"
@@ -8267,27 +8275,27 @@ msgstr "Tablet Wacom"
 
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:4
 msgid "Set button mappings and adjust stylus sensitivity for graphics tablets"
-msgstr ""
+msgstr "Tetapkan pemetaan butang dan laras kepekaan stilus untuk tablet-tablet grafik"
 
 #. Translators: Do NOT translate or transliterate this text (this is an icon
 #. file name)!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:7
 msgid "input-tablet"
-msgstr ""
+msgstr "input-tablet"
 
 #. Translators: Search terms to find the Wacom Tablet panel. Do NOT translate
 #. or localize the semicolons! The list MUST also end with a semicolon!
 #: panels/wacom/gnome-wacom-panel.desktop.in.in:18
 msgid "Tablet;Wacom;Stylus;Eraser;Mouse;"
-msgstr ""
+msgstr "Tablet;Wacom;Stilus;Pemadam;Tetikus;"
 
 #: panels/wacom/gnome-wacom-properties.ui:15
 msgid "Tablet (absolute)"
-msgstr ""
+msgstr "Tablet (mutlak)"
 
 #: panels/wacom/gnome-wacom-properties.ui:19
 msgid "Touchpad (relative)"
-msgstr ""
+msgstr "Touchpad (relatif)"
 
 #: panels/wacom/gnome-wacom-properties.ui:27
 msgid "Tablet Preferences"
@@ -8303,7 +8311,7 @@ msgstr "Tiada tablet dikesan"
 
 #: panels/wacom/gnome-wacom-properties.ui:141
 msgid "Please plug in or turn on your Wacom tablet"
-msgstr ""
+msgstr "Sila palamkan kuasa atau hidupkan tablet Wacom anda"
 
 #: panels/wacom/gnome-wacom-properties.ui:161
 msgid "Bluetooth Settings"
@@ -8311,7 +8319,7 @@ msgstr "Tetapan Bluetooth"
 
 #: panels/wacom/gnome-wacom-properties.ui:238
 msgid "Tracking Mode"
-msgstr ""
+msgstr "Mod Penjejakan"
 
 #: panels/wacom/gnome-wacom-properties.ui:266
 msgid "Left-Handed Orientation"
@@ -8319,11 +8327,11 @@ msgstr "Orientasi Kidal"
 
 #: panels/wacom/gnome-wacom-properties.ui:296
 msgid "Map to Monitor…"
-msgstr "Peta untuk Dipantau"
+msgstr "Petakan untuk Pantau..."
 
 #: panels/wacom/gnome-wacom-properties.ui:309
 msgid "Map Buttons…"
-msgstr "Butang Peta..."
+msgstr "Petakan Butang..."
 
 #: panels/wacom/gnome-wacom-properties.ui:322
 msgid "Calibrate…"
@@ -8331,11 +8339,11 @@ msgstr "Tentukur..."
 
 #: panels/wacom/gnome-wacom-properties.ui:340
 msgid "Adjust mouse settings"
-msgstr "Betulkan tetapan tetikus"
+msgstr "Laras tetapan tetikus"
 
 #: panels/wacom/gnome-wacom-properties.ui:356
 msgid "Adjust display resolution"
-msgstr "Betulkan resolusi paparan"
+msgstr "Laras resolusi paparan"
 
 #: panels/wacom/gsd-wacom-key-shortcut-button.c:217
 msgid "New shortcut…"
@@ -8343,15 +8351,15 @@ msgstr "Pintasan baharu..."
 
 #: panels/wacom/wacom-stylus-page.ui:25
 msgid "Default"
-msgstr "Default"
+msgstr "Lalai"
 
 #: panels/wacom/wacom-stylus-page.ui:29
 msgid "Middle Mouse Button Click"
-msgstr ""
+msgstr "Klik Butang Tengah Tetikus"
 
 #: panels/wacom/wacom-stylus-page.ui:33
 msgid "Right Mouse Button Click"
-msgstr ""
+msgstr "Klik Butang Kanan Tetikus"
 
 #: panels/wacom/wacom-stylus-page.ui:37 shell/cc-window.ui:242
 msgid "Back"
@@ -8363,23 +8371,23 @@ msgstr "Maju"
 
 #: panels/wacom/wacom-stylus-page.ui:79
 msgid "No stylus found"
-msgstr ""
+msgstr "Tiada stilus ditemui"
 
 #: panels/wacom/wacom-stylus-page.ui:93
 msgid "Please move your stylus to the proximity of the tablet to configure it"
-msgstr ""
+msgstr "Sila gerak stilus anda kedekatan tablet untuk mengkonfigurkannya"
 
 #: panels/wacom/wacom-stylus-page.ui:159
 msgid "Eraser Pressure Feel"
-msgstr ""
+msgstr "Rasa Tekanan Pemadam"
 
 #: panels/wacom/wacom-stylus-page.ui:180 panels/wacom/wacom-stylus-page.ui:340
 msgid "Soft"
-msgstr ""
+msgstr "Lembut"
 
 #: panels/wacom/wacom-stylus-page.ui:210 panels/wacom/wacom-stylus-page.ui:370
 msgid "Firm"
-msgstr ""
+msgstr "Kejat"
 
 #: panels/wacom/wacom-stylus-page.ui:233
 msgid "Top Button"
@@ -8391,23 +8399,23 @@ msgstr "Butang Bawah"
 
 #: panels/wacom/wacom-stylus-page.ui:291
 msgid "Lowest Button"
-msgstr ""
+msgstr "Butang Terbawah"
 
 #: panels/wacom/wacom-stylus-page.ui:320
 msgid "Tip Pressure Feel"
-msgstr ""
+msgstr "Rasa Tekanan Hujung Stilus"
 
 #: shell/appdata/gnome-control-center.appdata.xml.in:7
 msgid "GNOME Settings"
-msgstr ""
+msgstr "Tetapan-Tetapan GNOME"
 
 #: shell/appdata/gnome-control-center.appdata.xml.in:8
 msgid "Utility to configure the GNOME desktop"
-msgstr ""
+msgstr "Utiliti untuk mengkonfigur desktop GNOME"
 
 #: shell/appdata/gnome-control-center.appdata.xml.in:10
 msgid "Settings is the primary interface for configuring your system."
-msgstr ""
+msgstr "Tetapan-tetapan ialah antaramuka utama untuk mengkonfigur sistem anda."
 
 #: shell/appdata/gnome-control-center.appdata.xml.in:20
 msgid "The GNOME Project"
@@ -8415,27 +8423,27 @@ msgstr "Projek GNOME"
 
 #: shell/cc-application.c:58
 msgid "Display version number"
-msgstr ""
+msgstr "Nombor version paparan"
 
 #: shell/cc-application.c:59
 msgid "Enable verbose mode"
-msgstr "Benarkan mod panjang lebar"
+msgstr "Benarkan mod berjela"
 
 #: shell/cc-application.c:60
 msgid "Search for the string"
-msgstr "Cari rentetan"
+msgstr "Gelintar rentetan"
 
 #: shell/cc-application.c:61
 msgid "List possible panel names and exit"
-msgstr ""
+msgstr "Senaraikan nama panel yang mungkin kemudian keluar"
 
 #: shell/cc-application.c:62
 msgid "Panel to display"
-msgstr "Panel hendak dipaparkan"
+msgstr "Panel untuk dipaparkan"
 
 #: shell/cc-application.c:62
 msgid "[PANEL] [ARGUMENT…]"
-msgstr "[PANEL] [ARGUMENT…]"
+msgstr "[PANEL] [ARGUMEN…]"
 
 #: shell/cc-panel-loader.c:281
 msgid "Available panels:"
@@ -8447,18 +8455,18 @@ msgstr "Semua Tetapan"
 
 #: shell/cc-window.ui:185
 msgid "Primary Menu"
-msgstr ""
+msgstr "Menu Utama"
 
 #: shell/cc-window.ui:332
 msgid "Warning: Development Version"
-msgstr ""
+msgstr "Amaran: Versi Pembangunan"
 
 #: shell/cc-window.ui:333
 msgid ""
 "This version of Settings should only be used for development purposes. You "
 "may experience incorrect system behavior, data loss, and other unexpected "
 "issues. "
-msgstr ""
+msgstr "Versi Tetapan-Tetapan ini seharusnya boleh digunakan untuk tujuan-tujuan pembangunan. Anda mungkin mengalami kelakuan sistem yang pelik, kehilangan data, dan lain-lain isu-isu tidak dijangka."
 
 #: shell/cc-window.ui:344
 msgid "Help"
@@ -8468,7 +8476,7 @@ msgstr "Bantuan"
 #. file name)!
 #: shell/gnome-control-center.desktop.in.in:5
 msgid "org.gnome.Settings"
-msgstr ""
+msgstr "org.gnome.Settings"
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -8479,50 +8487,60 @@ msgstr "Keutamaan;Tetapan;"
 #: shell/help-overlay.ui:15
 msgctxt "shortcut window"
 msgid "General"
-msgstr "Umum"
+msgstr "Am"
 
 #: shell/help-overlay.ui:20
 msgctxt "shortcut window"
 msgid "Quit"
-msgstr "Berhenti"
+msgstr "Keluar"
 
 #: shell/help-overlay.ui:27 shell/help-overlay.ui:48
 msgctxt "shortcut window"
 msgid "Search"
-msgstr "Carian"
+msgstr "Gelintar"
 
 #: shell/help-overlay.ui:35
 msgctxt "shortcut window"
 msgid "Panels"
-msgstr ""
+msgstr "Panel"
 
 #: shell/help-overlay.ui:40
 msgctxt "shortcut window"
 msgid "Go back to previous panel"
-msgstr ""
+msgstr "Undur ke panel terdahulu"
 
 #: shell/help-overlay.ui:53
 msgctxt "shortcut window"
 msgid "Cancel search"
-msgstr ""
+msgstr "Batal gelintar"
 
 #: shell/org.gnome.ControlCenter.gschema.xml:5
 msgid "The identifier for the last Settings panel to be opened"
-msgstr ""
+msgstr "Pengecam untuk panel Tetapan-Tetapan terakhir yang dibuka"
 
 #: shell/org.gnome.ControlCenter.gschema.xml:6
 msgid ""
 "The identifier for the last Settings panel to be opened. Unrecognised values"
 " will be ignored and the first panel in the list selected."
-msgstr ""
+msgstr "Pengecam untuk panel Tetapan-Tetapan terakhir yang dibuka. Nilai-nilai tidak dikenal pasti akan diabaikan dan panel pertama dalam senarai dipilih."
 
 #: shell/org.gnome.ControlCenter.gschema.xml:13
 msgid "Show warning when running a development build of Settings"
-msgstr ""
+msgstr "Tunjuk amaran ketika menjalankan binaan pembangunan Tetapan-Tetapan"
 
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr "Sama ada Tetapan-Tetapan patut menunjukkan amaran ketika menjalankan binaan pembangunan."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/my.po
+++ b/po/my.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Burmese (http://www.transifex.com/endless-os/gnome-control-center/language/my/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "အိမ်လိပ်စာ"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1398,6 +1394,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5766,11 +5774,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6091,7 +6099,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8522,6 +8530,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:59+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/endless-os/gnome-control-center/language/nb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "Har tilgang til nettverk"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Hjem"
 
@@ -358,7 +358,7 @@ msgstr "Velg et bilde"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Gjeldende bakgrunn"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Legg til bilde …"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktiviteter"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Speil"
 msgid "Display Mode"
 msgstr "Skjermmodus"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primær skjerm"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "Dra skjermene for å tilpasse oppsettet. Velg en skjerm for å endre inn
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Plassering av skjerm"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5777,11 +5785,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Språk;Utforming;Tastatur;Inndata;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Velg lokasjon"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6102,7 +6110,7 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr "Varsellyd"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/nds.po
+++ b/po/nds.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Low German (http://www.transifex.com/endless-os/gnome-control-center/language/nds/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Heimat"
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/ne.po
+++ b/po/ne.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:55+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Nepali (http://www.transifex.com/endless-os/gnome-control-center/language/ne/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "गृह"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr "हालको पृष्ठभूमि"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "गतिविधिहरू"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1398,6 +1394,14 @@ msgstr "दर्पण"
 msgid "Display Mode"
 msgstr "प्रर्दशन मोड"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "प्रमुख डिस्प्ले"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1407,6 +1411,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "प्रदर्शन व्यवस्था"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5776,11 +5784,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "भाषा;खाका;किबोर्ड;आगत;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "_स्थान छान्नुहोस्"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ठिक छ"
 
@@ -6101,7 +6109,7 @@ msgstr "भोल्युम"
 msgid "Alert Sound"
 msgstr "सावधानि ध्वनि"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "१००%"
@@ -8534,6 +8542,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/nl.po
+++ b/po/nl.po
@@ -21,9 +21,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:07+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/endless-os/gnome-control-center/language/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -69,7 +69,7 @@ msgstr "Heeft netwerktoegang"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Persoonlijke map"
 
@@ -369,7 +369,7 @@ msgstr "Selecteer een afbeelding"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -404,7 +404,7 @@ msgstr "Vergrendelingsscherm instellen"
 
 #: panels/background/cc-background-chooser.ui:143
 msgid "Remove Background"
-msgstr ""
+msgstr "Achtergrond verwijderen"
 
 #: panels/background/cc-background-item.c:140
 msgid "multiple sizes"
@@ -428,10 +428,6 @@ msgstr "Huidige achtergrond"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Afbeelding toevoegen…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activiteiten"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1410,6 +1406,14 @@ msgstr "Spiegelen"
 msgid "Display Mode"
 msgstr "Beeldschermmodus"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primair scherm"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1419,6 +1423,10 @@ msgstr "Versleep schermen om overeen te komen met de fysieke opstelling van uw s
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Schermvolgorde"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -2341,7 +2349,7 @@ msgstr "Netwerkbeheer moet actief zijn."
 
 #: panels/network/cc-network-panel.ui:102
 msgid "Other Devices"
-msgstr ""
+msgstr "Overige apparaten"
 
 #: panels/network/cc-network-panel.ui:143
 #: panels/network/connection-editor/net-connection-editor.c:581
@@ -2441,19 +2449,19 @@ msgstr "Beveiliging"
 
 #: panels/network/connection-editor/ce-page.c:396
 msgid "Preserve"
-msgstr ""
+msgstr "Behouden"
 
 #: panels/network/connection-editor/ce-page.c:397
 msgid "Permanent"
-msgstr ""
+msgstr "Permanent"
 
 #: panels/network/connection-editor/ce-page.c:398
 msgid "Random"
-msgstr ""
+msgstr "Willekeurig"
 
 #: panels/network/connection-editor/ce-page.c:399
 msgid "Stable"
-msgstr ""
+msgstr "Stabiel"
 
 #: panels/network/connection-editor/ce-page.c:403
 msgid ""
@@ -5788,11 +5796,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Taal;Indeling;Toetsenbord;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Locatie kiezen"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Oké"
 
@@ -6113,7 +6121,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Waarschuwingsvolume"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8547,6 +8555,16 @@ msgstr "Waarschuwing tonen wanneer er een ontwikkelversie van Instellingen draai
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Of Instellingen een waarschuwing moet tonen wanneer er een ontwikkelversie draait."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/nn.po
+++ b/po/nn.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Norwegian Nynorsk (http://www.transifex.com/endless-os/gnome-control-center/language/nn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Heim"
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "Noverande bakgrunn"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivitetar"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5778,11 +5786,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6103,7 +6111,7 @@ msgstr "Lydstyrke"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100 %"
@@ -8536,6 +8544,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/nso.po
+++ b/po/nso.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Northern Sotho (http://www.transifex.com/endless-os/gnome-control-center/language/nso/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr "Bolumo"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/oc.po
+++ b/po/oc.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Vicki Niu <vicki@endlessm.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Occitan (post 1500) (http://www.transifex.com/endless-os/gnome-control-center/language/oc/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Dorsièr personal"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Rèireplan actual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activitats"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Clonar"
 msgid "Display Mode"
 msgstr "Mòde d’afichatge"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Disposicion dels ecrans"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5777,11 +5785,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Lenga;Disposicion;Clavièr;Entrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Seleccionar un emplaçament"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_D'acòrdi"
 
@@ -6102,7 +6110,7 @@ msgstr "Volum +"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100 %"
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/or.po
+++ b/po/or.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:12+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Oriya (http://www.transifex.com/endless-os/gnome-control-center/language/or/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "ମୂଳସ୍ଥାନ"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "ପ୍ରଚଳିତ ପୃଷ୍ଠଭୂମି"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "କାର୍ଯ୍ୟକ୍ରମଗୁଡ଼ିକ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "ପ୍ରତିଫଳକ"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1407,6 +1411,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5777,11 +5785,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ଭାଷା;ବିନ୍ୟାସ;କିବୋର୍ଡ;ନିବେଶ;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "ଗୋଟିଏ ସ୍ଥାନ ମନୋନୀତ କରନ୍ତୁ"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ଠିକ ଅଛି (_O)"
 
@@ -6102,7 +6110,7 @@ msgstr "ଭଲ୍ଯୁମ"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/pa.po
+++ b/po/pa.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:06+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Panjabi (Punjabi) (http://www.transifex.com/endless-os/gnome-control-center/language/pa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "ਨੈੱਟਵਰਕ ਪਹੁੰਚ ਹੈ"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "ਘਰ"
 
@@ -358,7 +358,7 @@ msgstr "ਤਸਵੀਰ ਚੁਣੋ"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "ਮੌਜੂਦਾ ਬੈਕਗਰਾਊਂਡ"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "…ਤਸਵੀਰ ਜੋੜੋ"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "ਸਰਗਰਮੀਆਂ"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "ਹੂ-ਬਹੂ"
 msgid "Display Mode"
 msgstr "ਡਿਸਪਲੇਅ ਮੋਡ"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "ਪ੍ਰਾਇਮਰੀ ਡਿਸਪਲੇਅ"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "ਡਿਸਪਲੇਆਂ ਨੂੰ ਆਪਣੇ ਅਸਲ ਡਿਸਪ�
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "ਡਿਸਪਲੇਅ ਤਰਤੀਬ"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5777,11 +5785,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ਭਾਸ਼ਾ;ਲੇਆਉਟ;ਕੀਬੋਰਡ;ਇੰਪੁੱਟ;ਖਾਕਾ;ਬੋਲੀ;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "ਟਿਕਾਣਾ ਚੁਣੋ"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "ਠੀਕ ਹੈ(_O)"
 
@@ -6102,7 +6110,7 @@ msgstr "ਵਾਲੀਅਮ"
 msgid "Alert Sound"
 msgstr "ਚੇਤਾਵਨੀ ਸਾਊਂਡ"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "੧੦੦%"
@@ -8535,6 +8543,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/pl.po
+++ b/po/pl.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:06+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Polish (http://www.transifex.com/endless-os/gnome-control-center/language/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "Ma dostęp do sieci"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Katalog domowy"
 
@@ -358,7 +358,7 @@ msgstr "Wybór obrazu"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Obecne tło"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Dodaj obraz…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Podgląd"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Ten sam obraz"
 msgid "Display Mode"
 msgstr "Tryb"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Główny ekran"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "Można przeciągać ekrany tak, aby pasowały do ich fizycznego ułożen
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Ułożenie ekranów"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5797,11 +5805,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Język;Dialekt;Układ;Layout;Klawiatura;Wprowadzanie;Wejście;Pisanie;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Wybór położenia"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Wybierz"
 
@@ -6122,7 +6130,7 @@ msgstr "Głośność"
 msgid "Alert Sound"
 msgstr "Dźwięk alarmu"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8560,6 +8568,16 @@ msgstr "Wyświetlanie ostrzeżenia podczas uruchamiania rozwojowej wersji Ustawi
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Czy Ustawienia mają wyświetlać ostrzeżenie podczas uruchamiania wersji rozwojowej."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ps.po
+++ b/po/ps.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Pushto (http://www.transifex.com/endless-os/gnome-control-center/language/ps/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/pt.po
+++ b/po/pt.po
@@ -36,9 +36,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Vicki Niu <vicki@endlessm.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/endless-os/gnome-control-center/language/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -84,7 +84,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Pasta pessoal"
 
@@ -384,7 +384,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -443,10 +443,6 @@ msgstr "Fundo atual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Atividades"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1425,6 +1421,14 @@ msgstr "Ecrãs em espelho"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1433,6 +1437,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5803,11 +5811,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposição;Teclado;Entrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Selecionar localização"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Aceitar"
 
@@ -6128,7 +6136,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8561,6 +8569,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -41,9 +41,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:54+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/endless-os/gnome-control-center/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -89,7 +89,7 @@ msgstr "Tem acesso à rede"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Pasta pessoal"
 
@@ -389,7 +389,7 @@ msgstr "Selecionar uma imagem"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -448,10 +448,6 @@ msgstr "Plano de fundo atual"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Adicionar imagem…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Atividades"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1430,6 +1426,14 @@ msgstr "Espelhar"
 msgid "Display Mode"
 msgstr "Modo da tela"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Tela primária"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1439,6 +1443,10 @@ msgstr "Arraste as telas para corresponder a sua configuração física de telas
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Organização de telas"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5808,11 +5816,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Idioma;Disposição;Teclado;Entrada;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Selecione localização"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6133,7 +6141,7 @@ msgstr "Volume"
 msgid "Alert Sound"
 msgstr "Som de alerta"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8567,6 +8575,16 @@ msgstr "Mostrar aviso quando estiver em uma compilação de desenvolvimento de C
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Se Configurações deve mostrar um aviso quando estiver sendo executando como uma compilação de desenvolvimento."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ro.po
+++ b/po/ro.po
@@ -22,9 +22,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:59+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Romanian (http://www.transifex.com/endless-os/gnome-control-center/language/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -70,7 +70,7 @@ msgstr "Are acces la rețea"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Acasă"
 
@@ -370,7 +370,7 @@ msgstr "Selectați o fotografie"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -429,10 +429,6 @@ msgstr "Fundalul curent"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Adaugă fotografie…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Activități"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1411,6 +1407,14 @@ msgstr "Oglindire"
 msgid "Display Mode"
 msgstr "Modul de afișaj"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Afișaj primar"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1420,6 +1424,10 @@ msgstr "Trageți afișaje pentru a le potrivi configurației fizice. Selectați 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Aranjamentul afișajelor"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5799,11 +5807,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;Limbă;Aranjament;Intrare;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Selectează locația"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Ok"
 
@@ -6124,7 +6132,7 @@ msgstr "Volum"
 msgid "Alert Sound"
 msgstr "Sunet de alertă"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8560,6 +8568,16 @@ msgstr "Arată avertismentul când se rulează o versiune de dezvoltare a Config
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Dacă programul Configurări ar trebui să arate un avertisment când se rulează o versiune de dezvoltare."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ru.po
+++ b/po/ru.po
@@ -21,9 +21,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:55+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Russian (http://www.transifex.com/endless-os/gnome-control-center/language/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -69,7 +69,7 @@ msgstr "Имеет доступ к сети"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Домашняя папка"
 
@@ -369,7 +369,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -428,10 +428,6 @@ msgstr "Текущий фон"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Обзор"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1410,6 +1406,14 @@ msgstr "Зеркальное отображение"
 msgid "Display Mode"
 msgstr "Режим дисплея"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Основной дисплей"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1419,6 +1423,10 @@ msgstr "Перетащите дисплеи в соответствии с фи�
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Расположение дисплея"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5808,11 +5816,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Язык;Раскладка;Клавиатура;Ввод;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Выберите расположение"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6133,7 +6141,7 @@ msgstr "Громкость"
 msgid "Alert Sound"
 msgstr "Звук уведомления"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8571,6 +8579,16 @@ msgstr "Показывать предупреждение при запуске 
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Должно ли показываться предупреждение при запуске сборки для разработки."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/rw.po
+++ b/po/rw.po
@@ -14,9 +14,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Kinyarwanda (http://www.transifex.com/endless-os/gnome-control-center/language/rw/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -62,7 +62,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -362,7 +362,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -420,10 +420,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1403,6 +1399,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1411,6 +1415,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5781,11 +5789,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6106,7 +6114,7 @@ msgstr "Igice"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8539,6 +8547,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/si.po
+++ b/po/si.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Sinhala (http://www.transifex.com/endless-os/gnome-control-center/language/si/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "නිවස"
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr ""
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "ක්‍රියාකාරකම්"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr "හඬ"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/sk.po
+++ b/po/sk.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:13+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Slovak (http://www.transifex.com/endless-os/gnome-control-center/language/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -60,7 +60,7 @@ msgstr "Má prístup k sieti"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Domov"
 
@@ -360,7 +360,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -419,10 +419,6 @@ msgstr "Aktuálne pozadie"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivity"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1401,6 +1397,14 @@ msgstr "Zrkadliť"
 msgid "Display Mode"
 msgstr "Režim displejov"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Hlavný displej"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1410,6 +1414,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Rozloženie displejov"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5799,11 +5807,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Jazyk;Rozloženie;Klávesnica;Vstup;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Výber miesta"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Ok"
 
@@ -6124,7 +6132,7 @@ msgstr "Hlasitosť"
 msgid "Alert Sound"
 msgstr "Zvuk varovania"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100 %"
@@ -8561,6 +8569,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/sl.po
+++ b/po/sl.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:08+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Slovenian (http://www.transifex.com/endless-os/gnome-control-center/language/sl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,7 +58,7 @@ msgstr "Ima dostop do omrežja"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Domača mapa"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Trenutno ozadje"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Dejavnosti"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Zrcali"
 msgid "Display Mode"
 msgstr "Način prikaza"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Prvi zaslon"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr "Premaknite zaslone, da bodo skladni z dejansko postavitvijo zaslonov. Z 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Postavitev zaslonov"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5797,11 +5805,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "jezik,razporeditev;tipkovnica;vnos;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Izbor mesta"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_V redu"
 
@@ -6122,7 +6130,7 @@ msgstr "Glasnost"
 msgid "Alert Sound"
 msgstr "Zvok opozoril"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100 %"
@@ -8560,6 +8568,16 @@ msgstr "Pokaži opozorilo med zagonom razvojne različice programa"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Ali naj se pokaže opozorilo, kadar je program zagnan v razvojnem načinu."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/sq.po
+++ b/po/sq.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Ardit Dani <ardit.dani@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Albanian (http://www.transifex.com/endless-os/gnome-control-center/language/sq/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Shtëpi"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -415,10 +415,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1398,6 +1394,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5776,11 +5784,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6101,7 +6109,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8534,6 +8542,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/sr.po
+++ b/po/sr.po
@@ -13,9 +13,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:56+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Serbian (http://www.transifex.com/endless-os/gnome-control-center/language/sr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -61,7 +61,7 @@ msgstr "Има приступ мрежи"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Личнo"
 
@@ -361,7 +361,7 @@ msgstr "Изаберите слику"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -420,10 +420,6 @@ msgstr "Тренутна позадина"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Додај слику…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Активности"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1402,6 +1398,14 @@ msgstr "Пресликано"
 msgid "Display Mode"
 msgstr "Режим екрана"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Главни екран"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1411,6 +1415,10 @@ msgstr "Превуците екране да одговарају вашем ф�
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Ређање екрана"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5790,11 +5798,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "језик;распоред;тастатура;унос;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Изабери место"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "У _реду"
 
@@ -6115,7 +6123,7 @@ msgstr "Јачина звука"
 msgid "Alert Sound"
 msgstr "Звук упозорења"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8551,6 +8559,16 @@ msgstr "Прикажи упозорење када је покренуто ра�
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Да ли Подешавања треба да приказују упозорење ако је покренуто развојно издање."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Serbian (Latin) (http://www.transifex.com/endless-os/gnome-control-center/language/sr@latin/)\n"
 "MIME-Version: 1.0\n"
@@ -61,7 +61,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Lično"
 
@@ -361,7 +361,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -420,10 +420,6 @@ msgstr "Trenutna pozadina"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktivnosti"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1402,6 +1398,14 @@ msgstr "Preslikano"
 msgid "Display Mode"
 msgstr "Režim ekrana"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Glavni ekran"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1411,6 +1415,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Ređanje ekrana"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5790,11 +5798,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "jezik;raspored;tastatura;unos;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Izaberi mesto"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "U _redu"
 
@@ -6115,7 +6123,7 @@ msgstr "Jačina zvuka"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8550,6 +8558,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/sv.po
+++ b/po/sv.po
@@ -16,9 +16,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:09+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Swedish (http://www.transifex.com/endless-os/gnome-control-center/language/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,7 +64,7 @@ msgstr "Har nätverksåtkomst"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Hem"
 
@@ -364,7 +364,7 @@ msgstr "Välj en bild"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -423,10 +423,6 @@ msgstr "Aktuell bakgrund"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Lägg till bild…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Aktiviteter"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1405,6 +1401,14 @@ msgstr "Spegling"
 msgid "Display Mode"
 msgstr "Skärmläge"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Primär skärm"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1414,6 +1418,10 @@ msgstr "Dra skärmar så de överensstämmer med din fysiska skärmuppställning
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Skärmuppställning"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5783,11 +5791,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Språk;Layout;Tangentbord;Inmatning;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Välj plats"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6108,7 +6116,7 @@ msgstr "Volym"
 msgid "Alert Sound"
 msgstr "Larmljud"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8542,6 +8550,16 @@ msgstr "Visa en varning då en utvecklingsversion av Inställningar körs"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Huruvida Inställningar ska visa en varning då en utvecklingsversion körs."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ta.po
+++ b/po/ta.po
@@ -16,9 +16,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:58+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Tamil (http://www.transifex.com/endless-os/gnome-control-center/language/ta/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,7 +64,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "இல்லம்"
 
@@ -364,7 +364,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -423,10 +423,6 @@ msgstr "நடப்பு பின்னணி"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "செயல்பாடுகள்"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1405,6 +1401,14 @@ msgstr "பிரதிபலிப்பு"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1413,6 +1417,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5783,11 +5791,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "மொழி;இடஅமைவு;விசைப்பலகை;உள்ளீடு;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "ஒரு இடத்தை தேர்ந்தெடுக்கவும்"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "சரி (_O)"
 
@@ -6108,7 +6116,7 @@ msgstr "தொகுதி"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8541,6 +8549,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/te.po
+++ b/po/te.po
@@ -15,9 +15,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:01+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Telugu (http://www.transifex.com/endless-os/gnome-control-center/language/te/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -63,7 +63,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "నివాసం"
 
@@ -363,7 +363,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -422,10 +422,6 @@ msgstr "ప్రస్తుత నేపథ్యం"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "కార్యకలాపాలు"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1404,6 +1400,14 @@ msgstr "మిర్రర్"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5782,11 +5790,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "భాష;నమూనా;కీబోర్డు;యిన్పుట్;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "స్థానము యెంపికచేయి"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "సరే (_O)"
 
@@ -6107,7 +6115,7 @@ msgstr "ధ్వనిస్థాయి"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8540,6 +8548,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/tg.po
+++ b/po/tg.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:55+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Tajik (http://www.transifex.com/endless-os/gnome-control-center/language/tg/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Асосӣ"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr "Пасзаминаи ҷорӣ"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Фаъолиятҳо"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1398,6 +1394,14 @@ msgstr "Оина"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5776,11 +5784,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Забон;Тарҳбандӣ;Клавиатура;Вуруд;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Интихоби ҷойгиршавӣ"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_OK"
 
@@ -6101,7 +6109,7 @@ msgstr "Баландии садо"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8534,6 +8542,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/th.po
+++ b/po/th.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Thai (http://www.transifex.com/endless-os/gnome-control-center/language/th/)\n"
 "MIME-Version: 1.0\n"
@@ -62,7 +62,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "บ้าน"
 
@@ -362,7 +362,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -421,10 +421,6 @@ msgstr "พื้นหลังปัจจุบัน"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "กิจกรรม"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1403,6 +1399,14 @@ msgstr "แสดงเหมือนกัน"
 msgid "Display Mode"
 msgstr "โหมดการแสดงผล"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "จอแสดงผลหลัก"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1412,6 +1416,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "แสดงการจัดเรียง"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5771,11 +5779,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "ภาษา;ผังแป้นพิมพ์;แป้นพิมพ์;ป้อนข้อความ;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "เลือกสถานที่"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_ตกลง"
 
@@ -6096,7 +6104,7 @@ msgstr "ความดัง"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8527,6 +8535,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/tk.po
+++ b/po/tk.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Turkmen (http://www.transifex.com/endless-os/gnome-control-center/language/tk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/tr.po
+++ b/po/tr.po
@@ -23,9 +23,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:17+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/endless-os/gnome-control-center/language/tr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -71,7 +71,7 @@ msgstr "Ağ erişimi var"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Ev"
 
@@ -371,7 +371,7 @@ msgstr "Resim seç"
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -430,10 +430,6 @@ msgstr "Geçerli arka plan"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr "Resim Ekle…"
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Etkinlikler"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1412,6 +1408,14 @@ msgstr "Aynala"
 msgid "Display Mode"
 msgstr "Ekran Kipi"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Birincil Ekran"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1421,6 +1425,10 @@ msgstr "Ekranları fiziksel kurulumunuzla eşleşecek biçimde sürükleyin. Aya
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Ekran Düzeni"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5790,11 +5798,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Dil;Yerleşim;Düzen;Klavye;Girdi;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Konum Seç"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Tamam"
 
@@ -6115,7 +6123,7 @@ msgstr "Ses"
 msgid "Alert Sound"
 msgstr "Uyarı Sesi"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "%100"
@@ -8549,6 +8557,16 @@ msgstr "Ayarlarʼın geliştirme inşasını çalıştırırken uyarı göster"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "Geliştirme inşası çalışırken Ayarlarʼın uyarı gösterip göstermeyeceği."
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/ug.po
+++ b/po/ug.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:57+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Uighur (http://www.transifex.com/endless-os/gnome-control-center/language/ug/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "ماكان"
 
@@ -357,7 +357,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -416,10 +416,6 @@ msgstr "نۆۋەتتىكى تەگلىك"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "پائالىيەتلەر"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1398,6 +1394,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1406,6 +1410,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5766,11 +5774,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;تىل;ھەرپتاختا;كىرگۈزۈش;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "ئورۇن تاللاش"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6091,7 +6099,7 @@ msgstr "ئاۋاز مىقدارى"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8522,6 +8530,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:16+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/endless-os/gnome-control-center/language/uk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Домівка"
 
@@ -359,7 +359,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -418,10 +418,6 @@ msgstr "Поточне тло"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Діяльність"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1400,6 +1396,14 @@ msgstr "Відзеркалля"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5798,11 +5806,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Мова;Розкладка;Клавіатура;Введення;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "Вибрати регіон"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "_Гаразд"
 
@@ -6123,7 +6131,7 @@ msgstr "Гучність"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8560,6 +8568,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/uz.po
+++ b/po/uz.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Uzbek (http://www.transifex.com/endless-os/gnome-control-center/language/uz/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5765,11 +5773,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6090,7 +6098,7 @@ msgstr "Tovush"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8521,6 +8529,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/vi.po
+++ b/po/vi.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/endless-os/gnome-control-center/language/vi/)\n"
 "MIME-Version: 1.0\n"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "Thư mục chứa ảnh"
 
@@ -358,7 +358,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -417,10 +417,6 @@ msgstr "Ảnh nền hiện tại"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "Hoạt động"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1399,6 +1395,14 @@ msgstr "Giống nhau"
 msgid "Display Mode"
 msgstr "Chế độ hiển thị"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "Màn hình chính"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1408,6 +1412,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "Sắp xếp màn hình"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5767,11 +5775,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Ngôn;ngữ;Ngon;ngu;Layout;Bố;trí;Bo;tri;Keyboard;Bàn;phím;Ban;phim;Kieu;go;Input;nhập;nhap;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "_Chọn vị trí"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "Đồn_g ý"
 
@@ -6092,7 +6100,7 @@ msgstr "Khối tin"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8523,6 +8531,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/wa.po
+++ b/po/wa.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Walloon (http://www.transifex.com/endless-os/gnome-control-center/language/wa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/xh.po
+++ b/po/xh.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Xhosa (http://www.transifex.com/endless-os/gnome-control-center/language/xh/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr "Isandi"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/yi.po
+++ b/po/yi.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Yiddish (http://www.transifex.com/endless-os/gnome-control-center/language/yi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5774,11 +5782,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6099,7 +6107,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8532,6 +8540,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/yo.po
+++ b/po/yo.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Yoruba (http://www.transifex.com/endless-os/gnome-control-center/language/yo/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,7 +55,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -413,10 +413,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1396,6 +1392,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1404,6 +1408,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5764,11 +5772,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6089,7 +6097,7 @@ msgstr ""
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8520,6 +8528,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -41,9 +41,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:15+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: e2f <projects@e2f.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/endless-os/gnome-control-center/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -89,7 +89,7 @@ msgstr "拥有网络访问"
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "主目录"
 
@@ -389,7 +389,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -448,10 +448,6 @@ msgstr "当前背景"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "活动"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1430,6 +1426,14 @@ msgstr "镜像"
 msgid "Display Mode"
 msgstr "显示模式"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "显示器"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1439,6 +1443,10 @@ msgstr "拖动显示器来匹配您的物理显示器布局。选择显示器可
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "显示装置"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5798,11 +5806,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;语言;布局;键盘;输入;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "选择位置"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "确定(_O)"
 
@@ -6123,7 +6131,7 @@ msgstr "音量"
 msgid "Alert Sound"
 msgstr "警报声"
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8555,6 +8563,16 @@ msgstr "运行开发版本的 GNOME 设置时显示警告"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "是否在运行开发版本的 GNOME 设置时显示警告。"
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 18:11+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Chinese (Hong Kong) (http://www.transifex.com/endless-os/gnome-control-center/language/zh_HK/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -60,7 +60,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "家"
 
@@ -360,7 +360,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -419,10 +419,6 @@ msgstr "目前的背景"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "概覽 "
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1401,6 +1397,14 @@ msgstr "鏡射"
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1409,6 +1413,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5769,11 +5777,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;語言;配置;鍵盤;輸入;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "選擇位置"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "確定(_O)"
 
@@ -6094,7 +6102,7 @@ msgstr "音量"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8525,6 +8533,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -13,9 +13,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:25+0000\n"
+"Last-Translator: Roddy Shuler <roddy@stanfordalumni.org>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/endless-os/gnome-control-center/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -61,7 +61,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr "家"
 
@@ -361,7 +361,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -420,10 +420,6 @@ msgstr "目前的背景"
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
 msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
-msgstr "概覽"
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
 msgid "Background"
@@ -1402,6 +1398,14 @@ msgstr "相同"
 msgid "Display Mode"
 msgstr "顯示器模式"
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr "主要顯示器"
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1411,6 +1415,10 @@ msgstr ""
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
 msgstr "排列顯示器組合方式"
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
+msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
 msgid "Display Configuration"
@@ -5770,11 +5778,11 @@ msgstr "preferences-desktop-locale"
 msgid "Language;Layout;Keyboard;Input;"
 msgstr "Language;Layout;Keyboard;Input;語言;配置;鍵盤;輸入;"
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr "選擇位置"
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr "確定(_O)"
 
@@ -6095,7 +6103,7 @@ msgstr "音量"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr "100%"
@@ -8527,6 +8535,16 @@ msgstr "顯示警告，當執行設定的開發構建版本"
 msgid ""
 "Whether Settings should show a warning when running a development build."
 msgstr "當執行開發構建版本時，是否在設定中顯示警告。"
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
+msgstr ""
 
 #. translators:
 #. * The number of sound outputs on a particular device

--- a/po/zu.po
+++ b/po/zu.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-control-center\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-18 14:28-0700\n"
-"PO-Revision-Date: 2019-09-24 17:53+0000\n"
-"Last-Translator: Philip Chimento <philip.chimento@gmail.com>\n"
+"POT-Creation-Date: 2019-10-03 17:24+0100\n"
+"PO-Revision-Date: 2019-10-03 16:24+0000\n"
+"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
 "Language-Team: Zulu (http://www.transifex.com/endless-os/gnome-control-center/language/zu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: panels/applications/cc-applications-panel.c:586
 #: panels/applications/cc-applications-panel.c:588
-#: panels/search/cc-search-locations-dialog.c:292
+#: panels/search/cc-search-locations-dialog.c:293
 msgid "Home"
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 #: panels/printers/pp-details-dialog.c:313
 #: panels/privacy/cc-privacy-panel.c:1270
 #: panels/region/cc-format-chooser.ui:24 panels/region/cc-input-chooser.ui:11
-#: panels/search/cc-search-locations-dialog.c:613
+#: panels/search/cc-search-locations-dialog.c:614
 #: panels/sharing/cc-sharing-panel.c:428
 #: panels/user-accounts/cc-add-user-dialog.ui:28
 #: panels/user-accounts/cc-avatar-chooser.c:107
@@ -414,10 +414,6 @@ msgstr ""
 
 #: panels/background/cc-background-panel.ui:63
 msgid "Add Picture…"
-msgstr ""
-
-#: panels/background/cc-background-preview.ui:55
-msgid "Activities"
 msgstr ""
 
 #: panels/background/gnome-background-panel.desktop.in.in:3
@@ -1397,6 +1393,14 @@ msgstr ""
 msgid "Display Mode"
 msgstr ""
 
+#: panels/display/cc-display-panel.ui:222
+msgid "Contains task bar"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:223
+msgid "Primary Display"
+msgstr ""
+
 #: panels/display/cc-display-panel.ui:245
 msgid ""
 "Drag displays to match your physical display setup. Select a display to "
@@ -1405,6 +1409,10 @@ msgstr ""
 
 #: panels/display/cc-display-panel.ui:252
 msgid "Display Arrangement"
+msgstr ""
+
+#: panels/display/cc-display-panel.ui:387
+msgid "Active Display"
 msgstr ""
 
 #: panels/display/cc-display-panel.ui:434
@@ -5775,11 +5783,11 @@ msgstr ""
 msgid "Language;Layout;Keyboard;Input;"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:610
+#: panels/search/cc-search-locations-dialog.c:611
 msgid "Select Location"
 msgstr ""
 
-#: panels/search/cc-search-locations-dialog.c:614
+#: panels/search/cc-search-locations-dialog.c:615
 msgid "_OK"
 msgstr ""
 
@@ -6100,7 +6108,7 @@ msgstr "Ivolumu"
 msgid "Alert Sound"
 msgstr ""
 
-#: panels/sound/cc-volume-slider.c:93
+#: panels/sound/cc-volume-slider.c:92
 msgctxt "volume"
 msgid "100%"
 msgstr ""
@@ -8533,6 +8541,16 @@ msgstr ""
 #: shell/org.gnome.ControlCenter.gschema.xml:14
 msgid ""
 "Whether Settings should show a warning when running a development build."
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:20
+msgid "Directories with avatar faces"
+msgstr ""
+
+#: shell/org.gnome.ControlCenter.gschema.xml:21
+msgid ""
+"Directories to override the default avatar faces installed by gnome-control-"
+"center."
 msgstr ""
 
 #. translators:


### PR DESCRIPTION
While checking that our Transifex integration is set up for this
project, I noticed that some human-facing strings were not marked for
translation - because we changed one downstream and it didn't change the
`.pot` file.

I submitted a fix upsteam at https://gitlab.gnome.org/GNOME/gnome-control-center/merge_requests/582 and backported it here. Because it conflicts with our downstream change to the string in question, I reverted that change, backported the upstream change, then reapplied the downstream string change. My hope is that this will make the next rebase easier :-)

https://phabricator.endlessm.com/T27764