### PR TITLE
cc-language-dialog: Increase height to 475px

### DIFF
--- a/panels/common/cc-language-chooser.ui
+++ b/panels/common/cc-language-chooser.ui
@@ -6,7 +6,7 @@
     <property name="modal">True</property>
     <property name="destroy_with_parent">True</property>
     <property name="default_width">400</property>
-    <property name="default_height">350</property>
+    <property name="default_height">475</property>
     <child type="action">
       <object class="GtkButton" id="select_button">
         <property name="label" translatable="yes">_Select</property>


### PR DESCRIPTION
Increase height so that "view-more-symbolic" icon appears
by default when the language-dialog is displayed. This
improves UI-feedback for the user for browsing additional
language entries.

Upstream MR:
https://gitlab.gnome.org/GNOME/gnome-control-center/merge_requests/633

If the above MR is merged, this commit can be dropped in
the next rebase.

---------
- No associated task.
- Was not a clean cherry-pick from MR due to these [changes ](https://gitlab.gnome.org/GNOME/gnome-control-center/commit/23a7401)I suppose.
- This unblocks my work on fixing openQA test : `parental_controls_setup`
https://github.com/endlessm/eos-openqa-tests/commits/uajain/staging-parental-controls-setup