### PR TITLE
T28600 unresponsive polkit dialog (quiet error)

### DIFF
--- a/panels/user-accounts/cc-app-permissions.c
+++ b/panels/user-accounts/cc-app-permissions.c
@@ -325,9 +325,26 @@ update_app_filter (CcAppPermissions *self)
 
   if (error)
     {
-      g_warning ("Error retrieving app filter for user '%s': %s",
-                  act_user_get_user_name (self->user),
-                  error->message);
+      /* It's expected that a non-admin user can't read another user's parental
+       * controls info unless the panel has been unlocked; ignore such an
+       * error.
+       */
+      if (act_user_get_uid (self->user) != getuid () &&
+          self->permission != NULL &&
+          !g_permission_get_allowed (self->permission) &&
+          g_error_matches (error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_PERMISSION_DENIED))
+        {
+          g_clear_error (&error);
+          g_debug ("Not enough permissions to retrieve app filter for user '%s'",
+                   act_user_get_user_name (self->user));
+        }
+      else
+        {
+          g_warning ("Error retrieving app filter for user '%s': %s",
+                      act_user_get_user_name (self->user),
+                      error->message);
+        }
+
       return;
     }
 


### PR DESCRIPTION
When a user who is not a sudoer clicks on another user in the Users
panel, if the panel is not unlocked it leads to an error message like
this:

Error retrieving app filter for user 'andrunko': Not allowed to query app filter data for user 1000

However it's expected behavior that the mct_manager_get_app_filter()
call will fail in this case, so check for such an error message and
clear it.

https://phabricator.endlessm.com/T28600