### PR TITLE
display: Fix the resolution going to be tested

### DIFF
--- a/panels/display/cc-display-config-dbus.c
+++ b/panels/display/cc-display-config-dbus.c
@@ -1239,6 +1239,7 @@ is_scaled_mode_allowed (CcDisplayConfigDBus *self,
 
 static gboolean
 is_scale_allowed_by_active_monitors (CcDisplayConfigDBus *self,
+                                     CcDisplayMode       *mode,
                                      double               scale)
 {
   GList *l;
@@ -1250,7 +1251,7 @@ is_scale_allowed_by_active_monitors (CcDisplayConfigDBus *self,
       if (!cc_display_monitor_is_active (CC_DISPLAY_MONITOR (m)))
         continue;
 
-      if (!is_scaled_mode_allowed (self, m->current_mode, scale))
+      if (!is_scaled_mode_allowed (self, mode, scale))
         return FALSE;
     }
 
@@ -1278,7 +1279,7 @@ cc_display_config_dbus_is_scaled_mode_valid (CcDisplayConfig *pself,
   CcDisplayConfigDBus *self = CC_DISPLAY_CONFIG_DBUS (pself);
 
   if (self->global_scale_required || cc_display_config_is_cloning (pself))
-    return is_scale_allowed_by_active_monitors (self, scale);
+    return is_scale_allowed_by_active_monitors (self, mode, scale);
 
   return is_scaled_mode_allowed (self, mode, scale);
 }


### PR DESCRIPTION
Gnome-control-center checks the enumerated display modes by
cc_display_config_is_scaled_mode_valid()
  ...
  cc_display_config_dbus_is_scaled_mode_valid()
to exclude unusable low resolutions.

However, it is the current using resolution that going to be tested by
is_scaled_mode_allowed() in is_scale_allowed_by_active_monitors(), if it
is global scaled required or configured as cloning mode originally.
Therefor, it will check current using resolution again and again,
instead of the enumerated one. This leads gnome-control-center building
wrong resolution list on the panel.

This patch replaces the current mode with the enumerated mode to have
the correct resolution to be tested by is_scaled_mode_allowed().

https://phabricator.endlessm.com/T29501