### PR TITLE
GNOME Settings should always use evince to view Endless terms of use

### DIFF
--- a/panels/common/cc-util.c
+++ b/panels/common/cc-util.c
@@ -306,7 +306,7 @@ find_terms_document_for_languages (const gchar *product_name,
 }
 
 gboolean
-cc_util_show_endless_terms_of_use (GtkWidget *widget)
+cc_util_show_endless_terms_of_use (void)
 {
   g_autofree gchar *path = NULL;
   const gchar * const * languages;
@@ -335,12 +335,8 @@ cc_util_show_endless_terms_of_use (GtkWidget *widget)
       return TRUE;
     }
 
-  GtkWidget *toplevel = gtk_widget_get_toplevel (widget);
-  gtk_show_uri_on_window (GTK_WINDOW (toplevel), pdf_uri,
-                          gtk_get_current_event_time (), &error);
-
-  if (error)
-    g_warning ("Unable to display terms and conditions PDF: %s", error->message);
+  const gchar *argv[] = { "evince", pdf_uri, NULL };
+  g_spawn_async (NULL, (char **)argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
 
   return TRUE;
 }

--- a/panels/common/cc-util.h
+++ b/panels/common/cc-util.h
@@ -27,4 +27,4 @@ char * cc_util_normalize_casefold_and_unaccent (const char *str);
 char * cc_util_get_smart_date                  (GDateTime *date);
 char * cc_util_time_to_string_text             (gint64 msecs);
 
-gboolean cc_util_show_endless_terms_of_use (GtkWidget *widget);
+gboolean cc_util_show_endless_terms_of_use (void);

--- a/panels/info-overview/cc-info-overview-panel.c
+++ b/panels/info-overview/cc-info-overview-panel.c
@@ -89,7 +89,7 @@ on_attribution_label_link (GtkLinkButton       *link_button,
   if (g_strcmp0 (uri, "attribution-link") != 0)
     return FALSE;
 
-  return cc_util_show_endless_terms_of_use (GTK_WIDGET (link_button));
+  return cc_util_show_endless_terms_of_use ();
 }
 
 static char *

--- a/panels/metrics/cc-metrics-panel.c
+++ b/panels/metrics/cc-metrics-panel.c
@@ -106,7 +106,7 @@ on_attribution_label_link (GtkLinkButton  *link_button,
   if (g_strcmp0 (uri, "attribution-link") != 0)
     return FALSE;
 
-  return cc_util_show_endless_terms_of_use (GTK_WIDGET (link_button));
+  return cc_util_show_endless_terms_of_use ();
 }
 
 static void


### PR DESCRIPTION
Libreoffice Draw started handling `application/pdf` mimetypes
hence, the "Endless Terms of use" pdf-uri started spawning
libreoffice instead of evince. This is happening because of [1]:
"Flatpak .desktop exports take precedence over system ones due to
the order of XDG_DATA_DIRS"
    
Workaround this situation by always spawning evince for viewing
Endless Terms of use, since it's a system (non-uninstall-able)
app.

[1] : https://cgit.freedesktop.org/libreoffice/core/tree/solenv/bin/assemble-flatpak.sh#n29 


(No associated task) 