### PR TITLE
Add launcher to launch parental controls app

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -208,7 +208,7 @@ config_h.set('HAVE_SNAP', enable_snap,
 # malcontent support
 enable_malcontent = get_option('malcontent')
 if enable_malcontent
-  malcontent_dep = dependency('malcontent-0', version: '>= 0.3.0')
+  malcontent_dep = dependency('malcontent-0', version: '>= 0.7.0')
 endif
 config_h.set('HAVE_MALCONTENT', enable_malcontent,
              description: 'Define to 1 if malcontent support is enabled')

--- a/panels/user-accounts/cc-user-panel.ui
+++ b/panels/user-accounts/cc-user-panel.ui
@@ -300,6 +300,49 @@
                                   </object>
                                 </child>
                                 <child>
+                                  <object class="GtkListBoxRow" id="parental_controls_row">
+                                    <property name="visible">False</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="border-width">10</property>
+                                        <property name="spacing">10</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="label" translatable="yes">_Parental Controls</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="mnemonic_widget">parental_controls_button_label</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkImage" id="parental_control_go_next">
+                                            <property name="visible">True</property>
+                                            <property name="icon-name">go-next-symbolic</property>
+                                            <style>
+                                              <class name="dim-label"/>
+                                            </style>
+                                          </object>
+                                          <packing>
+                                            <property name="pack_type">end</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="parental_controls_button_label">
+                                            <property name="visible">True</property>
+                                            <style>
+                                              <class name="dim-label"/>
+                                            </style>
+                                          </object>
+                                          <packing>
+                                            <property name="pack_type">end</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
                                   <object class="GtkListBoxRow" id="language_row">
                                     <property name="visible">True</property>
                                     <child>

--- a/panels/user-accounts/meson.build
+++ b/panels/user-accounts/meson.build
@@ -175,6 +175,10 @@ if enable_cheese
   deps += cheese_deps
 endif
 
+if enable_malcontent
+  deps += malcontent_dep
+endif
+
 cflags += [
   '-DGNOMELOCALEDIR="@0@"'.format(control_center_localedir),
   '-DHAVE_LIBPWQUALITY',


### PR DESCRIPTION
Refresh implementation of https://github.com/endlessm/gnome-control-center/pull/206

https://phabricator.endlessm.com/T29440

___ 

Depends on meson build changes in #212 #211 (now merged)