### PR TITLE
fixup! privacy: Add metrics panel controlling metrics service integration

### DIFF
--- a/panels/metrics/gnome-metrics-panel.desktop.in.in
+++ b/panels/metrics/gnome-metrics-panel.desktop.in.in
@@ -3,10 +3,10 @@ Name=Metrics
 Comment=Enable or disable Endless metrics collection
 Exec=gnome-control-center metrics
 # FIXME
-# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=system-help
 Terminal=false
 Type=Application
+NoDisplay=true
 Categories=GNOME;GTK;Settings;DesktopSettings;X-GNOME-Settings-Panel;X-GNOME-PrivacySettings;
 OnlyShowIn=GNOME;Unity;
 # Translators: Search terms to find the Privacy panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!


### PR DESCRIPTION
xgettext has been fixed to not extract Icon= fields for translation. I
took care of backporting the patch to Endless OS.

All other panels' desktop files have NoDisplay=true, except this one. As
a result it shows up twice in search results: once as an app, and once
in the Settings search provider.

![Capture d’écran de 2020-03-24 16-48-28](https://user-images.githubusercontent.com/86760/77453592-5a6e2280-6def-11ea-8eca-27adf4b4626e.png)
![Capture d’écran de 2020-03-24 16-48-37](https://user-images.githubusercontent.com/86760/77453596-5b9f4f80-6def-11ea-8cf0-5839ae76c00c.png)


https://phabricator.endlessm.com/T28873