### PR TITLE
eos: Add a transitional message about parental controls for admins

### DIFF
--- a/panels/user-accounts/cc-user-panel.ui
+++ b/panels/user-accounts/cc-user-panel.ui
@@ -328,6 +328,18 @@
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkImage" id="parental_control_information">
+                                            <property name="visible">False</property>
+                                            <property name="icon-name">dialog-information-symbolic</property>
+                                            <style>
+                                              <class name="dim-label"/>
+                                            </style>
+                                          </object>
+                                          <packing>
+                                            <property name="pack_type">end</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkLabel" id="parental_controls_button_label">
                                             <property name="visible">True</property>
                                             <style>
@@ -654,5 +666,18 @@
       <widget name="autologin_row"/>
       <widget name="last_login_row"/>
     </widgets>
+  </object>
+  <object class="GtkPopover" id="parental_controls_unavailable_popover">
+    <property name="can_focus">False</property>
+    <property name="border_width">12</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="wrap">True</property>
+        <property name="label" translatable="yes">Parental controls can now only be applied to non-administrator accounts. See the &lt;a href="https://community.endlessos.com/t/how-have-parental-controls-changed-in-endless-os-3-8/12313"&gt;FAQ entry&lt;/a&gt;.</property>
+        <property name="use-markup">True</property>
+      </object>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
EOS 3.7 and older supported setting parental controls on administrator
accounts, as that was how Hack was set up (the child user account was an
administrator). EOS 3.8 supports creating a separate administrator
account and leaving the child (main) user as a non-administrator.
Support for setting parental controls on an administrator account has
been dropped.

This commit adds a transitional message to direct users towards the
relevant FAQ entry about the change, which will give them information
about how to reconfigure their users so they can continue to apply
parental controls to their child.

This should not be upstreamed. It can be dropped from EOS 3.9 onwards.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T29385