### PR TITLE
user-accounts: Only reset password when removing password if previous mode was set-at-login

### DIFF
--- a/panels/user-accounts/cc-password-dialog.c
+++ b/panels/user-accounts/cc-password-dialog.c
@@ -227,7 +227,8 @@ ok_button_clicked_cb (CcPasswordDialog *self)
                         /* When setting the user password mode to none, when it
                          * was previously set-at-login, we need to reset the password,
                          * otherwise the mode will be set back to set-at-login */
-                        act_user_set_password (self->user, "", "");
+                        if (act_user_get_password_mode (self->user) == ACT_USER_PASSWORD_MODE_SET_AT_LOGIN)
+                                act_user_set_password (self->user, "", "");
                         act_user_set_password_mode (self->user, self->password_mode);
                         break;
 


### PR DESCRIPTION
This avoids the situation where when changing the users's own password accounts service will request a polkit authorization for the action `org.freedesktop.accounts.change-own-password` (which is by default configured to not keep admin auth) twice, first to reset the password to an empty one which expects the current/old password and another auth request to change the password mode, with this request expecting an empty password (reset in previous request) but then gnome-shell won't allow the user to authenticate with an empty (opposed to None) password (which is strange anyway).

Note that this issue doesn't happen when the user we are trying to remove the password from has password mode set to set-at-login, given in this case it would mean we are not trying to remove our own password and in turn accounts service will use the polkit action `org.freedesktop.accounts.user-administration` to allow changing the password and this action is by default set to keep admin auth).

Alternatively we could patch accountsservice to allow setting the password mode to `NONE` when previously set to `set-at-login` without resetting it back to `set-at-login` if we don't reset the password first, but that seems a bit more risky.

https://phabricator.endlessm.com/T29884