### PR TITLE
fixup! privacy: Add metrics panel controlling metrics service integra…

### DIFF
--- a/panels/common/gnome-control-center.rules.in
+++ b/panels/common/gnome-control-center.rules.in
@@ -1,7 +1,5 @@
 polkit.addRule(function(action, subject) {
-	if ((action.id == "com.endlessm.Metrics.SetEnabled" ||
-	     action.id == "com.endlessm.Metrics.ResetTrackingId" ||
-	     action.id == "org.freedesktop.locale1.set-locale" ||
+	if ((action.id == "org.freedesktop.locale1.set-locale" ||
 	     action.id == "org.freedesktop.locale1.set-keyboard" ||
 	     action.id == "org.freedesktop.hostname1.set-static-hostname" ||
 	     action.id == "org.freedesktop.hostname1.set-hostname" ||
@@ -11,4 +9,12 @@ polkit.addRule(function(action, subject) {
 	    subject.isInGroup ("@PRIVILEGED_GROUP@")) {
 		    return polkit.Result.YES;
 	    }
+
+	if (action.id == "com.endlessm.Metrics.SetEnabled" ||
+	    action.id == "com.endlessm.Metrics.ResetTrackingId") {
+		if (subject.local && subject.active && subject.isInGroup ("@PRIVILEGED_GROUP@"))
+			return polkit.Result.YES;
+		else
+			return polkit.Result.AUTH_ADMIN;
+	}
 });


### PR DESCRIPTION
…tion

This commit allows non-admin users to enable/disable metrics, or reset
the tracking ID, by entering an admin password. Previously, only admins
were allowed to even try.

It can be squashed into the original commit when we next rebase.

https://phabricator.endlessm.com/T29300