### PR TITLE
Revert "display: Add a method to retrieve the name of a monitor mode"

### DIFF
--- a/panels/display/cc-display-config-dbus.c
+++ b/panels/display/cc-display-config-dbus.c
@@ -22,7 +22,7 @@
 
 #include "cc-display-config-dbus.h"
 
-#define MODE_BASE_FORMAT "ssiiddad"
+#define MODE_BASE_FORMAT "siiddad"
 #define MODE_FORMAT "(" MODE_BASE_FORMAT "a{sv})"
 #define MODES_FORMAT "a" MODE_FORMAT
 #define MONITOR_SPEC_FORMAT "(ssss)"
@@ -47,7 +47,6 @@ struct _CcDisplayModeDBus
   CcDisplayMode parent_instance;
 
   char *id;
-  char *name;
   int width;
   int height;
   double refresh_rate;
@@ -73,14 +72,6 @@ cc_display_mode_dbus_equal (const CcDisplayModeDBus *m1,
     m1->height == m2->height &&
     m1->refresh_rate == m2->refresh_rate &&
     (m1->flags & MODE_INTERLACED) == (m2->flags & MODE_INTERLACED);
-}
-
-static const char *
-cc_display_mode_dbus_get_name (CcDisplayMode *pself)
-{
-  CcDisplayModeDBus *self = CC_DISPLAY_MODE_DBUS (pself);
-
-  return self->name;
 }
 
 static void
@@ -161,7 +152,6 @@ cc_display_mode_dbus_finalize (GObject *object)
   CcDisplayModeDBus *self = CC_DISPLAY_MODE_DBUS (object);
 
   g_free (self->id);
-  g_free (self->name);
   g_array_free (self->supported_scales, TRUE);
 
   G_OBJECT_CLASS (cc_display_mode_dbus_parent_class)->finalize (object);
@@ -175,7 +165,6 @@ cc_display_mode_dbus_class_init (CcDisplayModeDBusClass *klass)
 
   gobject_class->finalize = cc_display_mode_dbus_finalize;
 
-  parent_class->get_name = cc_display_mode_dbus_get_name;
   parent_class->get_resolution = cc_display_mode_dbus_get_resolution;
   parent_class->get_supported_scales = cc_display_mode_dbus_get_supported_scales;
   parent_class->get_preferred_scale = cc_display_mode_dbus_get_preferred_scale;
@@ -197,7 +186,6 @@ cc_display_mode_dbus_new (GVariant *variant)
 
   g_variant_get (variant, "(" MODE_BASE_FORMAT "@a{sv})",
                  &self->id,
-                 &self->name,
                  &self->width,
                  &self->height,
                  &self->refresh_rate,

--- a/panels/display/cc-display-config.c
+++ b/panels/display/cc-display-config.c
@@ -90,12 +90,6 @@ cc_display_mode_class_init (CcDisplayModeClass *klass)
 {
 }
 
-const char *
-cc_display_mode_get_name (CcDisplayMode *self)
-{
-  return CC_DISPLAY_MODE_GET_CLASS (self)->get_name (self);
-}
-
 void
 cc_display_mode_get_resolution (CcDisplayMode *self, int *w, int *h)
 {

--- a/panels/display/cc-display-config.h
+++ b/panels/display/cc-display-config.h
@@ -77,7 +77,6 @@ struct _CcDisplayModeClass
 {
   GObjectClass parent_class;
 
-  const char*   (*get_name)             (CcDisplayMode *self);
   void          (*get_resolution)       (CcDisplayMode *self, int *w, int *h);
   const double* (*get_supported_scales) (CcDisplayMode *self);
   double        (*get_preferred_scale)  (CcDisplayMode *self);
@@ -239,7 +238,6 @@ const char*       cc_display_monitor_get_ui_name            (CcDisplayMonitor  *
 const char*       cc_display_monitor_get_ui_number_name     (CcDisplayMonitor  *monitor);
 char*             cc_display_monitor_dup_ui_number_name     (CcDisplayMonitor  *monitor);
 
-const char*       cc_display_mode_get_name                  (CcDisplayMode     *mode);
 void              cc_display_mode_get_resolution            (CcDisplayMode     *mode,
                                                              int               *width,
                                                              int               *height);

--- a/panels/display/cc-display-settings.c
+++ b/panels/display/cc-display-settings.c
@@ -171,20 +171,14 @@ make_resolution_string (CcDisplayMode *mode)
   const char *interlaced = cc_display_mode_is_interlaced (mode) ? "i" : "";
   const char *aspect;
   int width, height;
-  const char *name;
 
   cc_display_mode_get_resolution (mode, &width, &height);
   aspect = make_aspect_string (width, height);
 
-  /* Retrieve the name assigned by mutter if possible, so that we
-   * show a non-confusing string to the user when underscanning.
-   */
-  name = cc_display_mode_get_name (mode);
-
   if (aspect != NULL)
-    return g_strdup_printf ("%s%s (%s)", name, interlaced, aspect);
+    return g_strdup_printf ("%d × %d%s (%s)", width, height, interlaced, aspect);
   else
-    return g_strdup_printf ("%s%s", name, interlaced);
+    return g_strdup_printf ("%d × %d%s", width, height, interlaced);
 }
 
 static gchar *


### PR DESCRIPTION
This reverts commit 98c31b355ebd2f8d74a7dc9a3124d2c36f2af151.

This depends on a (breaking) change to the Mutter D-Bus API that we don't currently have in our Mutter. Back out this feature so that those of us dogfooding master can configure our monitors :)

https://phabricator.endlessm.com/T30174