### PR TITLE
privacy: Mention that system apps can always use the camera/microphone

### DIFF
--- a/panels/camera/cc-camera-panel.ui
+++ b/panels/camera/cc-camera-panel.ui
@@ -72,7 +72,7 @@
                       <object class="GtkLabel">
                         <property name="visible">true</property>
                         <property name="margin-bottom">12</property>
-                        <property name="label" translatable="yes">Use of the camera allows applications to capture photos and video. Disabling the camera may cause some applications to not function properly.</property>
+                        <property name="label" translatable="yes">Use of the camera allows applications to capture photos and video. Disabling the camera may cause some applications to not function properly. System applications can always use the camera.</property>
                         <property name="wrap">1</property>
                         <property name="max-width-chars">50</property>
                         <property name="xalign">0</property>

--- a/panels/location/cc-location-panel.ui
+++ b/panels/location/cc-location-panel.ui
@@ -69,7 +69,7 @@
                     <child>
                       <object class="GtkLabel" id="location_description_label">
                         <property name="visible">true</property>
-                        <property name="label" translatable="yes">Location services allow applications to know your location. Using Wi-Fi and mobile broadband increases accuracy.</property>
+                        <property name="label" translatable="yes">Location services allow applications to know your location. Using Wi-Fi and mobile broadband increases accuracy. System applications can always access your location.</property>
                         <property name="wrap">1</property>
                         <property name="max-width-chars">50</property>
                         <property name="xalign">0</property>

--- a/panels/microphone/cc-microphone-panel.ui
+++ b/panels/microphone/cc-microphone-panel.ui
@@ -72,7 +72,7 @@
                       <object class="GtkLabel">
                         <property name="visible">true</property>
                         <property name="margin-bottom">12</property>
-                        <property name="label" translatable="yes">Use of the microphone allows applications to record and listen to audio. Disabling the microphone may cause some applications to not function properly.</property>
+                        <property name="label" translatable="yes">Use of the microphone allows applications to record and listen to audio. Disabling the microphone may cause some applications to not function properly. System applications can always use the microphone.</property>
                         <property name="wrap">true</property>
                         <property name="max-width-chars">50</property>
                         <property name="xalign">0</property>


### PR DESCRIPTION
These toggles only apply to the portal system, so only restrict access
for sandboxed apps. System apps (installed without sandboxing into
`/usr/bin`) can always access these resources on typical distributions.

In future, perhaps integration with a MAC (like SELinux) could restrict
access to the camera/microphone/GPS for system applications — but we
invented sandboxing to avoid having to do that, so it seems unlikely
that’s ever going to be implemented. If it is, this wording can change
again.

Upstream: https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/851
Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: #741

https://phabricator.endlessm.com/T27784