### PR TITLE
updates: Send a metric when automatic updates settings change

### DIFF
--- a/panels/updates/cc-updates-panel.c
+++ b/panels/updates/cc-updates-panel.c
@@ -22,9 +22,12 @@
 #include "cc-updates-panel.h"
 #include "cc-updates-resources.h"
 
+#include <eosmetrics/eosmetrics.h>
 #include <glib/gi18n.h>
 #include <libmogwai-tariff/tariff-loader.h>
 #include <NetworkManager.h>
+
+static const gchar *CC_METRIC_AUTOMATIC_UPDATES = "510f9741-823e-41a9-af2d-048895f990c0";
 
 #define NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED "connection.allow-downloads-when-metered"
 #define NM_SETTING_ALLOW_DOWNLOADS              "connection.allow-downloads"
@@ -145,6 +148,23 @@ ensure_setting_user (NMConnection *connection)
 }
 
 static void
+send_automatic_updates_metric (gboolean  allow_downloads_when_metered,
+                               gboolean  automatic_updates_enabled,
+                               gboolean  tariff_enabled,
+                               GVariant *tariff_variant)
+{
+  EmtrEventRecorder *recorder = emtr_event_recorder_get_default ();
+
+  emtr_event_recorder_record_event (recorder,
+                                    CC_METRIC_AUTOMATIC_UPDATES,
+                                    g_variant_new ("(bbbv)",
+                                                   allow_downloads_when_metered,
+                                                   automatic_updates_enabled,
+                                                   tariff_enabled,
+                                                   tariff_variant));
+}
+
+static void
 store_automatic_updates_setting (CcUpdatesPanel *self,
                                  NMConnection   *connection,
                                  gboolean        automatic_updates_enabled,
@@ -236,6 +256,12 @@ store_automatic_updates_setting (CcUpdatesPanel *self,
                                              NULL,
                                              on_network_changes_committed_cb,
                                              NULL);
+
+  /* Send a metric */
+  send_automatic_updates_metric (allow_downloads_when_metered,
+                                 automatic_updates_enabled,
+                                 tariff_enabled,
+                                 tariff_variant);
 }
 
 static void

--- a/panels/updates/cc-updates-panel.c
+++ b/panels/updates/cc-updates-panel.c
@@ -155,6 +155,7 @@ store_automatic_updates_setting (CcUpdatesPanel *self,
   g_autofree gchar *tariff_string = NULL;
   g_autoptr(GError) error = NULL;
   gboolean errored = FALSE;
+  gboolean allow_downloads_when_metered = TRUE;
 
   setting_user = ensure_setting_user (connection);
   g_assert (setting_user != NULL);
@@ -169,7 +170,7 @@ store_automatic_updates_setting (CcUpdatesPanel *self,
 
   nm_setting_user_set_data (setting_user,
                             NM_SETTING_ALLOW_DOWNLOADS_WHEN_METERED,
-                            "1",
+                            allow_downloads_when_metered ? "1" : "0",
                             &error);
 
   if (error)

--- a/panels/updates/meson.build
+++ b/panels/updates/meson.build
@@ -36,6 +36,7 @@ sources = common_sources + files(
 )
 
 deps = common_deps + [
+  dependency('eosmetrics-0'),
   dependency('libnm', version: '>= 1.8.0'),
   dependency('libnma', version: '>= 1.8.0'),
   dependency('mogwai-tariff-0', version: '>=0.1.0'),


### PR DESCRIPTION
This will give us some measure of how many people are using automatic
updates, and how many of those are on metered connections.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T29248