### PR TITLE
Revert "region: Change "Input Sources" label"

### DIFF
--- a/panels/region/cc-input-chooser.c
+++ b/panels/region/cc-input-chooser.c
@@ -945,7 +945,7 @@ get_locale_infos (CcInputChooser *self)
   /* Add a "Other" locale to hold the remaining input sources */
   info = g_new0 (LocaleInfo, 1);
   info->id = g_strdup ("");
-  info->name = g_strdup (C_("Keyboard Layout", "Other"));
+  info->name = g_strdup (C_("Input Source", "Other"));
   info->unaccented_name = g_strdup ("");
   info->untranslated_name = g_strdup ("");
   g_hash_table_replace (self->locales, g_strdup (info->id), info);

--- a/panels/region/cc-input-chooser.ui
+++ b/panels/region/cc-input-chooser.ui
@@ -2,7 +2,7 @@
 <interface>
   <!-- interface-requires gtk+ 3.0 -->
   <template class="CcInputChooser" parent="GtkDialog">
-    <property name="title" translatable="yes">Add a Keyboard Layout</property>
+    <property name="title" translatable="yes">Add an Input Source</property>
     <property name="modal">True</property>
     <property name="destroy_with_parent">True</property>
     <property name="resizable">True</property>

--- a/panels/region/cc-region-panel.ui
+++ b/panels/region/cc-region-panel.ui
@@ -234,7 +234,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Keyboard Layouts</property>
+                                <property name="label" translatable="yes">Input Sources</property>
                                 <attributes>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
@@ -376,7 +376,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_top">6</property>
-                <property name="label" translatable="yes">Keyboard Layout Options</property>
+                <property name="label" translatable="yes">Input Source Options</property>
                 <property name="margin_bottom">6</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>


### PR DESCRIPTION
This reverts commit e5752b63e87b1b5269f00a8421ecd094be6bd63f.

The change was rejected upstream at
https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/823.

https://phabricator.endlessm.com/T11054