### PR TITLE
applications: Remove eos-link-* special handling

### DIFF
--- a/panels/applications/cc-applications-panel.c
+++ b/panels/applications/cc-applications-panel.c
@@ -50,7 +50,6 @@
 #define MASTER_SCHEMA "org.gnome.desktop.notifications"
 #define APP_SCHEMA MASTER_SCHEMA ".application"
 #define APP_PREFIX "/org/gnome/desktop/notifications/application/"
-#define EOS_LINK_PREFIX "eos-link-"
 
 #define PORTAL_SNAP_PREFIX "snap."
 
@@ -1715,7 +1714,6 @@ populate_applications (CcApplicationsPanel *self)
 
       id = get_app_id (info);
       if (!g_app_info_should_show (info) ||
-          g_str_has_prefix (id, EOS_LINK_PREFIX) ||
           has_replaced_by (info))
         continue;
 


### PR DESCRIPTION
We are removing all web links from the OS, let's remove the special handling here also.

Depends on whether we are also dropping image personalities' specific web links - see endlessm/eos-image-builder#975.

https://phabricator.endlessm.com/T31560