### PR TITLE
info-overview: Implements usage of os-release to search for the OS logo

### DIFF
--- a/panels/info-overview/cc-info-overview-panel.c
+++ b/panels/info-overview/cc-info-overview-panel.c
@@ -69,6 +69,7 @@ struct _CcInfoOverviewPanel
   CcListRow       *hostname_row;
   CcListRow       *memory_row;
   GtkListBox      *os_box;
+  GtkImage        *os_logo;
   CcListRow       *os_name_row;
   CcListRow       *os_type_row;
   CcListRow       *processor_row;
@@ -824,6 +825,21 @@ cc_info_panel_row_activated_cb (CcInfoOverviewPanel *self,
 }
 
 static void
+setup_os_logo (CcInfoOverviewPanel *panel)
+{
+  g_autofree char *logo_name = g_get_os_info ("LOGO");
+  if (logo_name != NULL)
+    {
+      gtk_image_set_from_icon_name (panel->os_logo, logo_name, GTK_ICON_SIZE_INVALID);
+      gtk_image_set_pixel_size (panel->os_logo, 256);
+    }
+  else
+    {
+      gtk_image_set_from_resource (panel->os_logo, "/org/gnome/control-center/info-overview/GnomeLogoVerticalMedium.svg");
+    }
+}
+
+static void
 cc_info_overview_panel_class_init (CcInfoOverviewPanelClass *klass)
 {
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
@@ -840,6 +856,7 @@ cc_info_overview_panel_class_init (CcInfoOverviewPanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcInfoOverviewPanel, hostname_row);
   gtk_widget_class_bind_template_child (widget_class, CcInfoOverviewPanel, memory_row);
   gtk_widget_class_bind_template_child (widget_class, CcInfoOverviewPanel, os_box);
+  gtk_widget_class_bind_template_child (widget_class, CcInfoOverviewPanel, os_logo);
   gtk_widget_class_bind_template_child (widget_class, CcInfoOverviewPanel, os_name_row);
   gtk_widget_class_bind_template_child (widget_class, CcInfoOverviewPanel, os_type_row);
   gtk_widget_class_bind_template_child (widget_class, CcInfoOverviewPanel, processor_row);
@@ -870,6 +887,8 @@ cc_info_overview_panel_init (CcInfoOverviewPanel *self)
 
   info_overview_panel_setup_overview (self);
   info_overview_panel_setup_virt (self);
+
+  setup_os_logo (self);
 }
 
 GtkWidget *

--- a/panels/info-overview/cc-info-overview-panel.ui
+++ b/panels/info-overview/cc-info-overview-panel.ui
@@ -25,10 +25,9 @@
                 <property name="spacing">30</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkImage">
+                  <object class="GtkImage" id="os_logo">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="resource">/org/gnome/control-center/info-overview/GnomeLogoVerticalMedium.svg</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
By default info-overview panel shows the Gnome logo from a static
resource, currently every distro patches this component to show their logos

info-overview panel could use `/etc/os-release` file to fetch the OS logo
instead this static resource

(This is a clean zero-conflict backport from the GNOME 40 release)

https://phabricator.endlessm.com/T26931