### PR TITLE
user-accounts: Pass --user argument to select user in malcontent-control

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -210,6 +210,8 @@ config_h.set('HAVE_SNAP', enable_snap,
 enable_malcontent = get_option('malcontent')
 if enable_malcontent
   malcontent_dep = dependency('malcontent-0', version: '>= 0.7.0')
+  config_h.set('HAVE_MALCONTENT_0_10', malcontent_dep.version().version_compare('>= 0.10.0'),
+               description: 'Define to 1 if malcontent ≥ 0.10.0')
 endif
 config_h.set('HAVE_MALCONTENT', enable_malcontent,
              description: 'Define to 1 if malcontent support is enabled')

--- a/panels/user-accounts/cc-user-panel.c
+++ b/panels/user-accounts/cc-user-panel.c
@@ -1223,7 +1223,14 @@ spawn_malcontent_control (CcUserPanel *self)
 
         /* no-op if the user is administrator */
         if (act_user_get_account_type (user) != ACT_USER_ACCOUNT_TYPE_ADMINISTRATOR) {
-                const gchar *argv[] = { "malcontent-control", NULL };
+                const gchar *argv[] = {
+                        "malcontent-control",
+#ifdef HAVE_MALCONTENT_0_10
+                        "--user",
+                        act_user_get_user_name (user),
+#endif  /* HAVE_MALCONTENT_0_10 */
+                        NULL
+                };
                 g_spawn_async (NULL, (char **)argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
         }
 }


### PR DESCRIPTION
This eases the transition from g-c-c to malcontent-control a little.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Helps: https://gitlab.freedesktop.org/pwithnall/malcontent/-/issues/19

---

This is a trivial cherry-pick of https://gitlab.gnome.org/pwithnall/gnome-control-center/-/commit/e8d9fc565b to downstream EOS master.

https://phabricator.endlessm.com/T32617