### PR TITLE
Revert "applications: hide “Show in App Center” for App Center"

### DIFF
--- a/panels/applications/cc-applications-panel.c
+++ b/panels/applications/cc-applications-panel.c
@@ -1,6 +1,6 @@
 /* cc-applications-panel.c
  *
- * Copyright 2018-2022 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ * Copyright 2018 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1679,13 +1679,6 @@ update_panel (CcApplicationsPanel *self,
 
   self->current_app_id = get_app_id (info);
   self->current_portal_app_id = get_portal_app_id (info);
-
-  /* Don't show “Open in Software” button for Software itself. */
-  {
-    gboolean is_software = g_strcmp0 (self->current_app_id, "org.gnome.Software") == 0;
-    gtk_widget_set_visible (GTK_WIDGET (self->header_button),
-                            gtk_widget_get_visible (GTK_WIDGET (self->header_button)) && !is_software);
-  }
 }
 
 static void

--- a/panels/metrics/meson.build
+++ b/panels/metrics/meson.build
@@ -8,7 +8,6 @@ desktop_in = configure_file(
 )
 
 i18n.merge_file(
-  desktop,
   type: 'desktop',
   input: desktop_in,
   output: desktop,

--- a/panels/updates/meson.build
+++ b/panels/updates/meson.build
@@ -8,7 +8,6 @@ desktop_in = configure_file(
 )
 
 i18n.merge_file(
-  desktop,
   type: 'desktop',
   input: desktop_in,
   output: desktop,


### PR DESCRIPTION
This reverts commit 13c14a3c7a5983f8deb2ee895fec22e337c33ca8.

As of T33045, the change in downstream gnome-software to make it hide
itself has been dropped. This means that the “Show in App Center” button
should now work for gnome-software in gnome-control-center.

This commit and the one it reverts can be dropped next time we rebase.

https://phabricator.endlessm.com/T33045