### PR TITLE
search-provider: Show Parental Controls (if installed)

### DIFF
--- a/search-provider/control-center-search-provider.c
+++ b/search-provider/control-center-search-provider.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include <glib/gi18n.h>
+#include <gio/gdesktopappinfo.h>
 #include <stdlib.h>
 
 #include <gio/gio.h>
@@ -105,6 +106,15 @@ cc_search_provider_app_startup (GApplication *application)
 
   self->model = cc_shell_model_new ();
   cc_panel_loader_fill_model (self->model);
+
+  g_autoptr(GDesktopAppInfo) malcontent = g_desktop_app_info_new ("org.freedesktop.MalcontentControl.desktop");
+  if (malcontent != NULL)
+    {
+      cc_shell_model_add_item (self->model,
+                               CC_CATEGORY_ACCOUNT,
+                               G_APP_INFO (malcontent),
+                               "malcontent");
+    }
 }
 
 static void


### PR DESCRIPTION
This is a bit of a hack but it works fine.

![Screenshot from 2023-12-11 11-16-46](https://github.com/endlessm/gnome-control-center/assets/86760/b04f561b-86c7-4e7f-8305-90685562a8d2)


https://phabricator.endlessm.com/T35123