### PR TITLE
Revert "eos: Add metric for opening a panel"

### DIFF
--- a/shell/cc-window.c
+++ b/shell/cc-window.c
@@ -46,19 +46,6 @@
 
 #define DEFAULT_WINDOW_ICON_NAME "gnome-control-center"
 
-#include <eosmetrics/eosmetrics.h>
-
-#define PANEL_OPENED_EVENT_ID "3c5d59d2-6c3f-474b-95f4-ac6fcc192655"
-
-static void
-send_setting_panel_metric (const gchar *id)
-{
-  EmtrEventRecorder *recorder = emtr_event_recorder_get_default ();
-
-  emtr_event_recorder_record_event (recorder, PANEL_OPENED_EVENT_ID,
-                                    g_variant_new_string (id));
-}
-
 struct _CcWindow
 {
   AdwApplicationWindow parent;
@@ -189,8 +176,6 @@ activate_panel (CcWindow          *self,
   ellapsed_time = g_timer_elapsed (timer, NULL);
 
   g_debug ("Time to open panel '%s': %lfs", name, ellapsed_time);
-
-  send_setting_panel_metric (id);
 
   CC_RETURN (TRUE);
 }

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -107,7 +107,6 @@ libshell_dep = declare_dependency(
 shell_sources = common_sources + files('main.c')
 
 shell_deps = common_deps + [
-  dependency('eosmetrics-0'),
   libdevice_dep,
   liblanguage_dep,
   libwidgets_dep,


### PR DESCRIPTION
This reverts commit d1a25f52ea7fdf1cf4ef41ee4f52b3669130182c.

This event has not been ingested on the server since the switch to the
new v3 protocol & data model in eos4.0.

https://phabricator.endlessm.com/T35145
