### PR TITLE
fixup! user-accounts: Allow to create a user without a password

### DIFF
--- a/panels/user-accounts/cc-add-user-dialog.c
+++ b/panels/user-accounts/cc-add-user-dialog.c
@@ -790,12 +790,12 @@ password_mode_changed_cb (GtkCheckButton *button,
         if (!gtk_check_button_get_active (button))
                 return;
 
-        if (button == GTK_CHECK_BUTTON (self->local_no_password_radio))
-                mode = ACT_USER_PASSWORD_MODE_NONE;
-        else if (button == GTK_CHECK_BUTTON (self->local_password_radio))
-                mode = ACT_USER_PASSWORD_MODE_SET_AT_LOGIN;
-        else
+        if (button == GTK_CHECK_BUTTON (self->local_password_radio))
                 mode = ACT_USER_PASSWORD_MODE_REGULAR;
+        else if (button == GTK_CHECK_BUTTON (self->local_no_password_radio))
+                mode = ACT_USER_PASSWORD_MODE_NONE;
+        else
+                mode = ACT_USER_PASSWORD_MODE_SET_AT_LOGIN;
 
         self->local_password_mode = mode;
         gtk_widget_set_sensitive (GTK_WIDGET (self->password_group),

--- a/panels/user-accounts/cc-add-user-dialog.ui
+++ b/panels/user-accounts/cc-add-user-dialog.ui
@@ -151,7 +151,7 @@
                       <object class="GtkCheckButton" id="local_password_login_radio">
                         <property name="valign">center</property>
                         <property name="active">True</property>
-                        <signal name="toggled" handler="password_mode_changed_cb" object="CcAddUserDialog"/>
+                        <signal name="toggled" handler="password_mode_changed_cb" object="CcAddUserDialog" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -165,7 +165,7 @@
                         <property name="valign">center</property>
                         <property name="use_underline">True</property>
                         <property name="group">local_password_login_radio</property>
-                        <signal name="toggled" handler="password_mode_changed_cb" object="CcAddUserDialog"/>
+                        <signal name="toggled" handler="password_mode_changed_cb" object="CcAddUserDialog" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -179,7 +179,7 @@
                         <property name="valign">center</property>
                         <property name="use_underline">True</property>
                         <property name="group">local_password_login_radio</property>
-                        <signal name="toggled" handler="password_mode_changed_cb" object="CcAddUserDialog"/>
+                        <signal name="toggled" handler="password_mode_changed_cb" object="CcAddUserDialog" swapped="no"/>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
In the previous version of this patch (6d3efcbb03b27b6e580f437e10ab2b0227e0dc96), there were two mistakes:

- `password_mode_changed_cb` was receiving arguments in the wrong order, such that `GtkCheckButton *button` was actually a `CcAddUserDialog`, and `CcAddUserDialog *self` was actually a `GtkCheckButton`. I solved it by adding `swapped="no"` to the signal handler in the UI file. (Despite conventional understanding of how opposites work, `swapped="yes"` is the default).
- `password_mode_changed_cb` was incorrectly treating the `local_password_radio` button like the `local_login_password_radio` button. We have some really similar code in our patch for `cc-password-dialog.c` (261a9b9689fda13ab605e3b38fbedd5edd4dc91d). I made sure these two match each other.

I was wondering how that happened, but I see this patch changed quite a bit since EOS 5.1 (4f67d0fc0621f862087dbdb63d27cdda4ff87c4c), so it makes sense to me.

https://phabricator.endlessm.com/T35217