### PR TITLE
fixup! privacy: Add metrics panel controlling metrics service integration

### DIFF
--- a/panels/metrics/cc-metrics-panel.ui
+++ b/panels/metrics/cc-metrics-panel.ui
@@ -5,7 +5,7 @@
     <child type="titlebar-end">
       <object class="GtkSwitch" id="enable_metrics_switch">
         <property name="valign">center</property>
-        <signal name="state-set" handler="metrics_switch_active_changed_cb"/>
+        <signal name="state-set" handler="on_metrics_switch_state_set"/>
         <accessibility>
           <property name="label" translatable="yes">Enable Metrics</property>
         </accessibility>


### PR DESCRIPTION
Remove redundant calls to `gtk_switch_set_state` with the metrics toggle switch. Instead, bind switch `state` directly to the value of the D-Bus object property, and set the `active` property to follow when it changes. With this change, the switch's `state` property refers to the `Enabled` property of the metrics daemon, while the `active` property refers to the user's intent. Since Gtk 4.9.3, it is necessary to control the state and active properties independently.

https://phabricator.endlessm.com/T35277