### PR TITLE
Don't specify [dark_mode_]distributor_logo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "subprojects/gvc"]
-	path = subprojects/gvc
-	url = https://gitlab.gnome.org/GNOME/libgnome-volume-control.git

--- a/debian/rules
+++ b/debian/rules
@@ -36,8 +36,6 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		-Dprivileged_group=sudo \
 		-Ddocumentation=true \
-		-Ddistributor_logo=$(DISTRIBUTOR_LOGO) \
-		-Ddark_mode_distributor_logo=$(DISTRIBUTOR_LOGO) \
 		$(MALCONTENT) \
 		$(SNAP)
 


### PR DESCRIPTION
gnome-control-center has code that looks up LOGO from /etc/os-release, and then sets the icon search list to [$LOGO-text, $LOGO] (or in dark mode [$LOGO-text-dark, $LOGO-text, $LOGO-dark, $LOGO]. On Endless OS we have LOGO=endlessos in os-release. The eos-logos package ships /usr/share/pixmaps/endlessos.svg and
/usr/share/pixmaps/endlessos-text.svg. So the text version is preferred.

However Debian's packaging sets the distributor_logo and dark_mode_distributor_logo build options to non-empty paths, specifically /usr/share/icons/vendor/scalable/emblems/emblem-vendor.svg. We do not install any file at that path, so Settings → About shows no logo.

Remove these build flags, restoring the logo displayed in EOS 5.

https://phabricator.endlessm.com/T35355