### PR TITLE
location: Remove Mozilla Location Service reference

### DIFF
--- a/panels/location/cc-location-panel.ui
+++ b/panels/location/cc-location-panel.ui
@@ -37,8 +37,6 @@
                   <object class="AdwPreferencesGroup">
                     <property name="description" translatable="yes">Location services allow applications to know your location. Using Wi-Fi and mobile broadband increases accuracy.
 
-Uses Mozilla Location Service: &lt;a href=&apos;https://location.services.mozilla.com/privacy&apos;&gt;Privacy Policy&lt;/a&gt;
-
 Allow the applications below to determine your location. Applications without sandboxing can always determine your location, and do not appear here.</property>
                     <child>
                       <object class="GtkListBox" id="location_apps_list_box">


### PR DESCRIPTION
This service has been decommissioned and the privacy policy link is 404.

Upstream: https://gitlab.gnome.org/GNOME/gnome-control-center/-/issues/2959

https://phabricator.endlessm.com/T35587
